### PR TITLE
2 fixes and a few unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ tmp
 *~
 .DotSettings
 *StyleCop*
+*.ncrunchsolution
+*.GhostDoc.xml
+*.ncrunchproject

--- a/StackExchange.Profiling.Tests/MiniProfileHandlerTests.cs
+++ b/StackExchange.Profiling.Tests/MiniProfileHandlerTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Web;
+using NUnit.Framework;
+using Subtext.TestLibrary;
+
+namespace StackExchange.Profiling.Tests
+{
+    [TestFixture]
+    class MiniProfilerHandlerTests
+    {
+        [Test]
+        [TestCase("BRILLANT", 404)]
+        [TestCase("underscore.js", 404)]
+        [TestCase("jquery.1.7.1.js", 404)]
+        [TestCase("jquery.tmpl.js", 404)]
+        [TestCase("jquery.tmpl.js", 404)]
+        [TestCase("results-list", 200)]
+        [TestCase("includes.js", 200)]
+        [TestCase("includes.css", 200)]
+        public void GivenContext_WhenAResourceIsRequested_ThenTheCorrectHttpStatusCodeIsReturned(string resourceName, int expectedHttpStatus)
+        {
+            // Arrange
+            var sut = new MiniProfilerHandler();
+
+            // Act
+            var res = GetRequestResponseHttpStatus(sut, resourceName);
+
+            // Assert
+            Assert.AreEqual(expectedHttpStatus, res);
+        }
+        [Test]
+        [TestCase(true, 200)]
+        [TestCase(false, 401)]
+        public void GivenContext_WhenIndexIsRequested_ThenTheCorrectHttpStatusCodeIsReturned(bool isRequestAuthorized, int expectedHttpStatus)
+        {
+            // Arrange
+            var sut = new MiniProfilerHandler();
+            MiniProfiler.Settings.Results_List_Authorize = request => isRequestAuthorized;
+
+            // Act
+            var res = GetRequestResponseHttpStatus(sut, "/results-index");
+            
+            // Assert
+            Assert.AreEqual(expectedHttpStatus, res);
+        }
+
+        private static int GetRequestResponseHttpStatus(MiniProfilerHandler handler, string resourceName)
+        {
+            using (new HttpSimulator("/mini-profiler-resources/", @"c:\").SimulateRequest(new Uri("http://localhost/mini-profiler-resources"+resourceName)))
+            {
+                handler.ProcessRequest(HttpContext.Current);
+                return HttpContext.Current.Response.StatusCode;
+            }
+        }
+    }
+}

--- a/StackExchange.Profiling.Tests/StackExchange.Profiling.Tests.csproj
+++ b/StackExchange.Profiling.Tests/StackExchange.Profiling.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="BaseTestTest.cs">
       <DependentUpon>BaseTest.cs</DependentUpon>
     </Compile>
+    <Compile Include="MiniProfileHandlerTests.cs" />
     <Compile Include="ProtobufSerializationTest.cs" />
     <Compile Include="lib\HaackHttpSimulator\HttpSimulator.cs" />
     <Compile Include="lib\HaackHttpSimulator\ReflectionHelper.cs" />


### PR DESCRIPTION
Changes to pull
- Fixed: GetResource would generate a 500 when a file was not found. Now it returns 404; Added unit tests
- Fixed: results-index's HTML linked to files that were removed in a previous UI version and included in includes.js
