### PR TITLE
Adding compression to results

### DIFF
--- a/StackExchange.Profiling.Tests/MiniProfileHandlerTests.cs
+++ b/StackExchange.Profiling.Tests/MiniProfileHandlerTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Specialized;
+using System.IO.Compression;
 using System.Web;
 using NUnit.Framework;
 using Subtext.TestLibrary;
@@ -28,6 +30,7 @@ namespace StackExchange.Profiling.Tests
             // Assert
             Assert.AreEqual(expectedHttpStatus, res);
         }
+
         [Test]
         [TestCase(true, 200)]
         [TestCase(false, 401)]
@@ -44,12 +47,54 @@ namespace StackExchange.Profiling.Tests
             Assert.AreEqual(expectedHttpStatus, res);
         }
 
+		[Test]
+		[TestCase("gzip", typeof(GZipStream))]
+		[TestCase("deflate", typeof(DeflateStream))]
+		[TestCase("unknown", null)]
+		[TestCase("", null)]
+		public void GivenContext_WhenIndexIsRequested_ThenTheCorrectHttpStatusCodeIsReturned(string acceptEncoding, Type expectedEncodingFilterType)
+		{
+			// Arrange
+			var sut = new MiniProfilerHandler();
+
+			// Act
+			var res = GetRequestResponseEncoding(sut, "includes.js", acceptEncoding);
+
+			// Assert
+			// due the limitations of the HttpSimulator, we can't access the header values because it needs iis integrated pipeline mode.
+			// instead we return the type of the response filter
+
+			if (expectedEncodingFilterType == null)
+			{
+				Assert.AreNotEqual(typeof(GZipStream), res);
+				Assert.AreNotEqual(typeof(DeflateStream), res);
+			}
+			else
+			{
+				Assert.AreEqual(expectedEncodingFilterType, res);
+			}
+		}
+
         private static int GetRequestResponseHttpStatus(MiniProfilerHandler handler, string resourceName)
         {
             using (new HttpSimulator("/mini-profiler-resources/", @"c:\").SimulateRequest(new Uri("http://localhost/mini-profiler-resources"+resourceName)))
             {
                 handler.ProcessRequest(HttpContext.Current);
                 return HttpContext.Current.Response.StatusCode;
+            }
+        }
+
+        private static Type GetRequestResponseEncoding(MiniProfilerHandler handler, string resourceName, string encoding)
+        {
+	        var headers = new NameValueCollection();
+	        headers.Add("Accept-encoding", encoding);
+
+	        using (new HttpSimulator("/mini-profiler-resources/", @"c:\").SimulateRequest(new Uri("http://localhost/mini-profiler-resources"+resourceName), HttpVerb.GET, headers))
+            {
+                handler.ProcessRequest(HttpContext.Current);
+
+				////return HttpContext.Current.Response.Headers["Content-encoding"];
+	            return HttpContext.Current.Response.Filter.GetType();
             }
         }
     }

--- a/StackExchange.Profiling/Helpers/Compression.cs
+++ b/StackExchange.Profiling/Helpers/Compression.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Web;
+
+namespace StackExchange.Profiling.Helpers
+{
+	internal static class Compression
+	{
+		public static void EncodeStreamAndAppendResponseHeaders(HttpRequest request, HttpResponse response)
+		{
+			var encoding = request.Headers["Accept-Encoding"];
+			EncodeStreamAndAppendResponseHeaders(response, encoding);
+		}
+
+		public static void EncodeStreamAndAppendResponseHeaders(HttpResponse response, string acceptEncoding)
+		{
+			if (acceptEncoding == null) return;
+
+			var preferredEncoding = ParsePreferredEncoding(acceptEncoding);
+			if (preferredEncoding == null) return;
+
+			response.AppendHeader("Content-Encoding", preferredEncoding);
+			response.AppendHeader("Vary", "Accept-Encoding");
+			if (preferredEncoding == "deflate")
+			{
+				response.Filter = new DeflateStream(response.Filter, CompressionMode.Compress, true);
+			}
+			if (preferredEncoding == "gzip")
+			{
+				response.Filter = new GZipStream(response.Filter, CompressionMode.Compress, true);
+			}
+		}
+
+		static readonly string[] AllowedEncodings = new[] { "gzip", "deflate" };
+
+		static string ParsePreferredEncoding(string acceptEncoding)
+		{
+			return acceptEncoding
+				.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(type => type.Split(';'))
+				.Select(parts => new
+				{
+					encoding = parts[0].Trim(),
+					qvalue = ParseQValueFromSecondArrayElement(parts)
+				})
+				.Where(x => AllowedEncodings.Contains(x.encoding))
+				.OrderByDescending(x => x.qvalue)
+				.Select(x => x.encoding)
+				.FirstOrDefault();
+		}
+
+		static float ParseQValueFromSecondArrayElement(string[] parts)
+		{
+			const float defaultQValue = 1f;
+			if (parts.Length < 2) return defaultQValue;
+
+			float qvalue;
+			return float.TryParse(parts[1].Trim(), out qvalue) ? qvalue : defaultQValue;
+		}
+	}
+}

--- a/StackExchange.Profiling/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/MiniProfilerHandler.cs
@@ -98,7 +98,12 @@ namespace StackExchange.Profiling
                     break;
             }
 
-            context.Response.Write(output);
+	        if (!string.IsNullOrEmpty(output))
+	        {
+		        Compression.EncodeStreamAndAppendResponseHeaders(context.Request, context.Response);
+	        }
+
+			context.Response.Write(output);
         }
 
         /// <summary>

--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="ClientTimings.cs" />
     <Compile Include="CustomTiming.cs" />
+    <Compile Include="Helpers\Compression.cs" />
     <Compile Include="MiniProfilerHandler.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
The output of the MiniProfilerHandler is now compressed, if the request supports that.
Added unit tests to test the behaviour of the compression.

This would significantly reduce the transmitted information because:
- "results" is sending lists of guids all the time
- "includes.css", "includes.js" and "includes.tmpl" is reduced in size

I took care about clients that does not support the compression at all.
