### PR TITLE
Exclude EF assemblies from stacktrace

### DIFF
--- a/StackExchange.Profiling.EntityFramework/MiniProfilerEF.cs
+++ b/StackExchange.Profiling.EntityFramework/MiniProfilerEF.cs
@@ -143,7 +143,7 @@
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework");
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework.SqlServer");
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework.SqlServerCompact");
-            MiniProfiler.Settings.ExcludeAssembly("mscorlib");
+            MiniProfiler.Settings.ExcludeAssembly(typeof(MiniProfilerEF).Assembly.GetName().Name);
         }
     }
 }

--- a/StackExchange.Profiling.EntityFramework6/MiniProfilerEF6.cs
+++ b/StackExchange.Profiling.EntityFramework6/MiniProfilerEF6.cs
@@ -71,7 +71,7 @@
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework");
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework.SqlServer");
             MiniProfiler.Settings.ExcludeAssembly("EntityFramework.SqlServerCompact");
-            MiniProfiler.Settings.ExcludeAssembly("mscorlib");
+            MiniProfiler.Settings.ExcludeAssembly(typeof(MiniProfilerEF6).Assembly.GetName().Name);
         }
     }
 }


### PR DESCRIPTION
By excluding the entity framework assemblies those methods which are not relevant for the user will disappear and your own relevant ones will be more visible. This can be done in projects using these packages, but it is usually missed.
