### PR TITLE
Exclude mscorlib assembly from stacktrace

### DIFF
--- a/StackExchange.Profiling/MiniProfiler.Settings.cs
+++ b/StackExchange.Profiling/MiniProfiler.Settings.cs
@@ -107,6 +107,7 @@ namespace StackExchange.Profiling
                     "System.Data.Linq",
                     "System.Web",
                     "System.Web.Mvc",
+                    "mscorlib",
                 };
 
                 // for normal usage, this will return a System.Diagnostics.Stopwatch to collect times - unit tests can explicitly set how much time elapses


### PR DESCRIPTION
Excluded the mscorlib since things like CreateValue LazyInitValue get_Value in the stacktrace doesn't add any value for the user.
