### PR TITLE
Stacksnippet optimize

### DIFF
--- a/StackExchange.Profiling/Helpers/StackTraceSnippet.cs
+++ b/StackExchange.Profiling/Helpers/StackTraceSnippet.cs
@@ -6,64 +6,64 @@ using System.Reflection;
 namespace StackExchange.Profiling.Helpers
 {
     /// <summary>
-	/// Gets part of a stack trace containing only methods we care about.
-	/// </summary>
-	public class StackTraceSnippet
-	{
+    ///     Gets part of a stack trace containing only methods we care about.
+    /// </summary>
+    public class StackTraceSnippet
+    {
         private const string AspNetEntryPointMethodName = "System.Web.HttpApplication.IExecutionStep.Execute";
 
-		/// <summary>
-		/// Gets the current formatted and filtered stack trace.
-		/// </summary>
-		/// <returns>Space separated list of methods</returns>
-		public static string Get()
-		{
-			var frames = new StackTrace().GetFrames();
+        /// <summary>
+        ///     Gets the current formatted and filtered stack trace.
+        /// </summary>
+        /// <returns>Space separated list of methods</returns>
+        public static string Get()
+        {
+            var frames = new StackTrace().GetFrames();
             if (frames == null || MiniProfiler.Settings.StackMaxLength <= 0)
-			{
-				return "";
-			}
+            {
+                return "";
+            }
 
-			var methods = new List<string>();
-		    int stackLength = -1; // Starts on -1 instead of zero to compensate for adding 1 first time
+            var methods = new List<string>();
+            int stackLength = -1; // Starts on -1 instead of zero to compensate for adding 1 first time
 
-			foreach (StackFrame t in frames)
-			{
-				var method = t.GetMethod();
+            foreach (StackFrame t in frames)
+            {
+                var method = t.GetMethod();
 
-				// no need to continue up the chain
-				if (method.Name == AspNetEntryPointMethodName)
-					break;
+                // no need to continue up the chain
+                if (method.Name == AspNetEntryPointMethodName)
+                    break;
 
                 if (stackLength >= MiniProfiler.Settings.StackMaxLength)
                     break;
 
-				var assembly = method.Module.Assembly.GetName().Name;
-				if (!ShouldExcludeType(method) 
-                    && !MiniProfiler.Settings.AssembliesToExclude.Contains(assembly) 
+                var assembly = method.Module.Assembly.GetName().Name;
+                if (!ShouldExcludeType(method)
+                    && !MiniProfiler.Settings.AssembliesToExclude.Contains(assembly)
                     && !MiniProfiler.Settings.MethodsToExclude.Contains(method.Name))
-				{
-					methods.Add(method.Name);
-				    stackLength += method.Name.Length + 1; // 1 added for spaces.
-				}
-			}
+                {
+                    methods.Add(method.Name);
+                    stackLength += method.Name.Length + 1; // 1 added for spaces.
+                }
+            }
 
             return string.Join(" ", methods);
-		}
+        }
 
         private static bool ShouldExcludeType(MethodBase method)
-		{
-			var t = method.DeclaringType;
+        {
+            var t = method.DeclaringType;
 
-			while (t != null)
-			{
-				if (MiniProfiler.Settings.TypesToExclude.Contains(t.Name))
-					return true;
+            while (t != null)
+            {
+                if (MiniProfiler.Settings.TypesToExclude.Contains(t.Name))
+                    return true;
 
-				t = t.DeclaringType;
-			}
+                t = t.DeclaringType;
+            }
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Took care of a TODO in the code. Instead of building a long string and then cutting, it will only build as long of a string as it needs to.
Also reformatted file since it was messy with mixed tabs and spaces.
