### PR TITLE
Added a Step extension to allow a step to specify its parent

### DIFF
--- a/Sample.Console/Program.cs
+++ b/Sample.Console/Program.cs
@@ -76,18 +76,18 @@
         {
             var mp = MiniProfiler.Start("Locking");
             Action doWork = () => Thread.Sleep(new Random().Next(1, 50));
-
-            using (mp.Step("outer"))
+            
+            using (var outer = mp.Step("outer"))
             {
                 System.Threading.Tasks.Parallel.For(0, 5, i =>
                 {
                     doWork();
 
-                    using (mp.Step("step " + i))
+                    using (var step = outer.SubStep("step " + i))
                     {
                         doWork();
 
-                        using (mp.Step("sub-step" + i))
+                        using (var subStep = step.SubStep("sub-step" + i))
                         {
                             doWork();
                         }

--- a/StackExchange.Profiling/MiniProfiler.cs
+++ b/StackExchange.Profiling/MiniProfiler.cs
@@ -458,13 +458,13 @@ namespace StackExchange.Profiling
             }
         }
 
-        internal IDisposable StepImpl(string name, decimal? minSaveMs = null, bool? includeChildrenWithMinSave = false)
+        internal Timing StepImpl(string name, decimal? minSaveMs = null, bool? includeChildrenWithMinSave = false)
         {
             return new Timing(this, Head, name, minSaveMs, includeChildrenWithMinSave);
         }
 
         [Obsolete("Please use the StepImpl(string name) overload instead of this one. ProfileLevel is going away.")]
-        internal IDisposable StepImpl(string name, ProfileLevel level)
+        internal Timing StepImpl(string name, ProfileLevel level)
         {
             return level > Level ? null : StepImpl(name);
         }

--- a/StackExchange.Profiling/MiniProfilerExtensions.cs
+++ b/StackExchange.Profiling/MiniProfilerExtensions.cs
@@ -49,9 +49,9 @@ namespace StackExchange.Profiling
         /// <param name="profiler">The current profiling session or null.</param>
         /// <param name="name">A descriptive name for the code that is encapsulated by the resulting IDisposable's lifetime.</param>
         /// <returns>the profile step</returns>
-        public static IDisposable Step(this MiniProfiler profiler, string name)
+        public static Timing Step(this MiniProfiler profiler, string name)
         {
-            return profiler == null ? null : profiler.StepImpl(name);
+            return profiler == null ? (Timing)null : profiler.StepImpl(name);
         }
 
         /// <summary>
@@ -62,9 +62,9 @@ namespace StackExchange.Profiling
         /// <param name="level">This step's visibility level; allows filtering when <see cref="MiniProfiler.Start(string)"/> is called.</param>
         /// <returns>the profile step</returns>
         [Obsolete("Please use the Step(string name) overload instead of this one. ProfileLevel is going away.")]
-        public static IDisposable Step(this MiniProfiler profiler, string name, ProfileLevel level)
+        public static Timing Step(this MiniProfiler profiler, string name, ProfileLevel level)
         {
-            return profiler == null ? null : profiler.StepImpl(name, level);
+            return profiler == null ? (Timing)null : profiler.StepImpl(name, level);
         }
 
         /// <summary>
@@ -79,9 +79,9 @@ namespace StackExchange.Profiling
         /// <returns></returns>
         /// <remarks>If <paramref name="includeChildren"/> is set to true and a child is removed due to its use of StepIf, then the 
         /// time spent in that time will also not count for the current StepIf calculation.</remarks>
-        public static IDisposable StepIf(this MiniProfiler profiler, string name, decimal minSaveMs, bool includeChildren = false)
+        public static Timing StepIf(this MiniProfiler profiler, string name, decimal minSaveMs, bool includeChildren = false)
         {
-            return profiler == null ? null : profiler.StepImpl(name, minSaveMs, includeChildren);
+            return profiler == null ? (Timing)null : profiler.StepImpl(name, minSaveMs, includeChildren);
         }
 
         /// <summary>
@@ -236,6 +236,21 @@ namespace StackExchange.Profiling
             }
 
             return text.ToString();
+        }
+
+        /// <summary>
+        /// Create a sub-step
+        /// </summary>
+        /// <param name="parent">The parent timing.  If this is null, SubStep will return null</param>
+        /// <param name="name"></param>
+        /// <returns>A new step that is a child of the parent timing, or null if the parent was null</returns>
+        public static Timing SubStep(this Timing parent, string name)
+        {
+            if (parent == null) 
+            {
+                return null;
+            }
+            return new Timing(parent.Profiler, parent, name);
         }
     }
 }


### PR DESCRIPTION
Also updated the minithreaded console example to show how to consume it.

This allowed the sub-timings to show under their correct parent.
