### PR TITLE
Fixed ProfiledDbProviderFactory

### DIFF
--- a/StackExchange.Profiling/Data/ProfiledDbProviderFactory.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbProviderFactory.cs
@@ -24,7 +24,6 @@ namespace StackExchange.Profiling.Data
         /// Initialises a new instance of the <see cref="ProfiledDbProviderFactory"/> class.
         /// proxy provider factory
         /// </summary>
-        /// <param name="profiler">The profiler.</param>
         /// <param name="tail">The tail.</param>
         public ProfiledDbProviderFactory(DbProviderFactory tail)
         {
@@ -150,7 +149,6 @@ namespace StackExchange.Profiling.Data
         /// <summary>
         /// Allow to re-initialise the provider factory.
         /// </summary>
-        /// <param name="profiler">The profiler.</param>
         /// <param name="tail">The tail.</param>
         public void InitProfiledDbProviderFactory(DbProviderFactory tail)
         {


### PR DESCRIPTION
As far as I can see through attempting to use the ProfiledDbProviderFactory class, it is broken. I don't think we should specify the profiler in the construction of the factory as surely that means we always use the same one?

Suggested resolution is to resolve it as and when required.
