### PR TITLE
add Spatial support for EF6

### DIFF
--- a/StackExchange.Profiling/Data/ProfiledDbDataReader.cs
+++ b/StackExchange.Profiling/Data/ProfiledDbDataReader.cs
@@ -76,6 +76,11 @@ namespace StackExchange.Profiling.Data
             get { return _reader.RecordsAffected; }
         }
 
+        public DbDataReader WrappedReader
+        {
+            get { return _reader; }
+        }
+
         /// <summary>
         /// The 
         /// </summary>


### PR DESCRIPTION
The default provider services doesn't have implementation for spatial services, without these any spatial queries fail. This is based on some work on the old github repo and extended to support selecting with spatial filters and returning spatial objects.
