### PR TITLE
Added a new constructor for SqlServerStorage

### DIFF
--- a/StackExchange.Profiling/StackExchange.Profiling.csproj
+++ b/StackExchange.Profiling/StackExchange.Profiling.csproj
@@ -46,6 +46,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Runtime.Serialization" />

--- a/StackExchange.Profiling/Storage/DatabaseStorageBase.cs
+++ b/StackExchange.Profiling/Storage/DatabaseStorageBase.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Configuration;
 
     /// <summary>
     /// Understands how to save MiniProfiler results to a MSSQL database, allowing more permanent storage and querying of slow results.
@@ -21,6 +22,23 @@
         protected DatabaseStorageBase(string connectionString)
         {
             ConnectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="DatabaseStorageBase"/> class. 
+        /// Returns a new <c>SqlServerDatabaseStorage</c> object that will insert into the database identified by connection string settings.
+        /// </summary>
+        /// <param name="connectionStringSettings">
+        /// The connection string settings read from ConfigurationManager.ConnectionStrings["connection"]
+        /// </param>
+        protected DatabaseStorageBase(ConnectionStringSettings connectionStringSettings)
+        {
+            if (connectionStringSettings == null)
+            {
+                throw new ArgumentNullException("connectionStringSettings");
+            }
+
+            this.ConnectionString = connectionStringSettings.ConnectionString;
         }
 
         /// <summary>

--- a/StackExchange.Profiling/Storage/SqlServerStorage.cs
+++ b/StackExchange.Profiling/Storage/SqlServerStorage.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Configuration;
     using System.Data.Common;
     using System.Data.SqlClient;
     using System.Diagnostics.CodeAnalysis;
@@ -24,13 +25,24 @@ SELECT * FROM MiniProfilerTimings WHERE MiniProfilerId = @id ORDER BY StartMilli
 SELECT * FROM MiniProfilerClientTimings WHERE MiniProfilerId = @id ORDER BY Start;";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SqlServerStorage"/> class. 
+        /// Initializes a new instance of the <see cref="SqlServerStorage"/> class with the specified connection string.
         /// </summary>
         /// <param name="connectionString">
-        /// The connection String.
+        /// The connection string to use.
         /// </param>
         public SqlServerStorage(string connectionString)
             : base(connectionString)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerStorage"/> class with the specified connection string settings.
+        /// </summary>
+        /// <param name="connectionStringSettings">
+        /// The connection string settings read from ConfigurationManager.ConnectionStrings["connection"]
+        /// </param>
+        public SqlServerStorage(ConnectionStringSettings connectionStringSettings)
+            :base(connectionStringSettings.ConnectionString)
         {
         }
         


### PR DESCRIPTION
This allows SqlServerStorage to be instantiated as `new
SqlServerStorage(ConnectionManager.ConnectionStrings["ConnectionName"]);`
which is useful if your application has the connection string specified
in the app.config or web.config rather than inline in code.
