### PR TITLE
Update to EFProfiledDBProviderServices for EF6 with MySql

### DIFF
--- a/StackExchange.Profiling.EntityFramework6/EFProfiledDbProviderServices.cs
+++ b/StackExchange.Profiling.EntityFramework6/EFProfiledDbProviderServices.cs
@@ -41,6 +41,9 @@ namespace StackExchange.Profiling.Data
             if (_tail == null)
             {
                 FieldInfo field = typeof(T).GetField("Instance", BindingFlags.Public | BindingFlags.Static);
+                if(field == null)
+                    field = typeof(T).GetField("Instance", BindingFlags.NonPublic | BindingFlags.Static);
+
                 if(field != null)
                     _tail = (T)field.GetValue(null);
             }


### PR DESCRIPTION
When a public property or field named "Instance" is not found, look for a non-public field instead.  Resolves issue with EF6 and MySql where the Instance field on MySqlProviderServices is non public.
