### PR TITLE
Support for proxies and load balancers

### DIFF
--- a/StackExchange.Profiling/IpAddressProvider.cs
+++ b/StackExchange.Profiling/IpAddressProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 
 namespace StackExchange.Profiling
 {
@@ -16,8 +17,15 @@ namespace StackExchange.Profiling
         /// </summary>
         public string GetUser(HttpRequest request)
         {
-            return string.Format("{0}, {1}", request.ServerVariables["REMOTE_ADDR"] ?? "",
-                                             request.ServerVariables["HTTP_X_FORWARDED_FOR"] ?? "");
+            // If there's no X_FORWARDED_FOR header, just return REMOTE_ADDR
+            if (String.IsNullOrWhiteSpace(request.ServerVariables["HTTP_X_FORWARDED_FOR"]))
+            {
+                return request.ServerVariables["REMOTE_ADDR"] ?? "";
+            }
+
+            // Otherwise return the concatenation of the REMOTE_ADDR and the X_FORWARDED_FOR header
+            return string.Format("{0} - {1}", request.ServerVariables["REMOTE_ADDR"] ?? "",
+                                              request.ServerVariables["HTTP_X_FORWARDED_FOR"]);
         }
     }
 }


### PR DESCRIPTION
Combine both the REMOTE_ADDR header (which is the connecting device's IP address), plus the HTTP_X_FORWARDED_FOR header if present (which is set by some proxy servers and load balancers) when determining the user's IP address. This allows us to have a unique per-user view, even when behind a proxy or load balancer.
