### PR TITLE
Fix for issue #89

### DIFF
--- a/StackExchange.Profiling/SqlFormatters/InlineFormatter.cs
+++ b/StackExchange.Profiling/SqlFormatters/InlineFormatter.cs
@@ -42,7 +42,10 @@ namespace StackExchange.Profiling.SqlFormatters
                     ? p.Name 
                     : Regex.Match(commandText, "([@:?])" + p.Name, RegexOptions.IgnoreCase).Value;
                 var value = GetParameterValue(p);
-                commandText = Regex.Replace(commandText, "(" + name + ")([^0-9A-z]|$)", m => value + m.Groups[2], RegexOptions.IgnoreCase);
+                if(!string.IsNullOrEmpty(name))
+                {
+                    commandText = Regex.Replace(commandText, "(" + name + ")([^0-9A-z]|$)", m => value + m.Groups[2], RegexOptions.IgnoreCase);
+                }
             }
 
             return commandText;


### PR DESCRIPTION
Issue #89: InlineFormatter corrupts SQL when a parameter is missing 

https://github.com/MiniProfiler/dotnet/issues/89
