### PR TITLE
only format RequestResultArgs if the profiler has been started

### DIFF
--- a/StackExchange.Profiling.RavenDb/RavenMiniProfiler.cs
+++ b/StackExchange.Profiling.RavenDb/RavenMiniProfiler.cs
@@ -18,7 +18,7 @@
         {
 
             if (store != null && store.JsonRequestFactory != null)
-                store.JsonRequestFactory.LogRequest += (sender, r) => IncludeTiming(JsonFormatter.FormatRequest(r));
+                store.JsonRequestFactory.LogRequest += (sender, r) => IncludeTiming(r);
 
         }
 
@@ -27,12 +27,14 @@
             if (MiniProfiler.Current == null || MiniProfiler.Current.Head == null)
                 return;
 
-            MiniProfiler.Current.Head.AddCustomTiming("raven", new CustomTiming(MiniProfiler.Current, BuildCommandString(request))
+            var formattedRequest = JsonFormatter.FormatRequest(request);
+
+            MiniProfiler.Current.Head.AddCustomTiming("raven", new CustomTiming(MiniProfiler.Current, BuildCommandString(formattedRequest))
             {
                 Id = Guid.NewGuid(),
-                DurationMilliseconds = (decimal)request.DurationMilliseconds,
-                FirstFetchDurationMilliseconds = (decimal)request.DurationMilliseconds,
-                ExecuteType = request.Status.ToString()
+                DurationMilliseconds = (decimal)formattedRequest.DurationMilliseconds,
+                FirstFetchDurationMilliseconds = (decimal)formattedRequest.DurationMilliseconds,
+                ExecuteType = formattedRequest.Status.ToString()
             });
         }
 


### PR DESCRIPTION
RequestResultArgs is formatted for every request even if the profiler is not started and before the check to see if MiniProfiler.Current is null. This formatting can mean quite a bit of JSON parsing. This is unnecessary work when the profiler has not been started.

This change moves this formatting until *after* the null check to see if the profiler has been started so that it does not format requests when it won't even use the result.