### PR TITLE
Change SqlStatements access modifier to protected

### DIFF
--- a/StackExchange.Profiling/Storage/SqlServerStorage.cs
+++ b/StackExchange.Profiling/Storage/SqlServerStorage.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Load the SQL statements (using Dapper Multiple Results)
         /// </summary>
-        private const string SqlStatements = @"
+        protected string SqlStatements = @"
 SELECT * FROM MiniProfilers WHERE Id = @id;
 SELECT * FROM MiniProfilerTimings WHERE MiniProfilerId = @id ORDER BY StartMilliseconds;
 SELECT * FROM MiniProfilerClientTimings WHERE MiniProfilerId = @id ORDER BY Start;";


### PR DESCRIPTION
Short Version: other sql execution methods can be overridden, but this one cannot (e.g. Save).  As such derived code has to live with these limited select statements instead of having the opportunity to customize them.  To resolve this I propose changing the access modifier from 'private const' to 'protected'

Long Version:
Rational is:
1)  Would like to use NuGet package instead of building source code locally with each build
2)  Custom storage engine in its own project inherits from SqlServerStorage.
3)  Custom storage engine modifies the queries as the backing DB has been changed.
4)  Custom storage engine can't get access to 'private const SqlStatements'
5)  Can't X-Copy many/all the methods as the MiniProfiler class (used line 303) is defined as 'internal' (remember custom storage engine is in another project) and the build fails.