### PR TITLE
[Closes #107] Add RavenDB 3.0 compatibility

### DIFF
--- a/StackExchange.Profiling.RavenDb/StackExchange.Profiling.RavenDb.csproj
+++ b/StackExchange.Profiling.RavenDb/StackExchange.Profiling.RavenDb.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,6 +66,12 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="README.md" />
+    <None Include="Scripts\jquery-2.2.0.min.map" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Scripts\jquery-2.2.0.intellisense.js" />
+    <Content Include="Scripts\jquery-2.2.0.js" />
+    <Content Include="Scripts\jquery-2.2.0.min.js" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
For issue #107.

I updated the `RavenMiniProfiler` implementation to be compatible with the new Async server client in Raven 3.0. This also maintains backwards compatibility with RavenDB 2.5 since the API is the same.

In Raven 2.5, all requests were synchronous so `HttpContext.Current` was accessible from the `LogRequest` event. However, in 3.0, everything is async-first, so more often than not, when `LogRequest` is thrown, it's on a different thread context which does not have access to `HttpContext.Current` so it could never find `MiniProfiler.Current`.

It's a little awkward but essentially this handles a different `ConfigureRequest` event which is thrown on every Raven request and is *before* any request is made so `HttpContext.Current` is available. We create a handler we pass that context/profiler into the `IncludeTiming` function to add a timing. Once the timing is added, we unsubscribe from the request since we aren't sure we can reuse the same context.

I also discovered a couple bugs that I addressed:

- Sometimes accessing MiniProfiler.Current can result in a NRE even when checking null (I'm not 100% sure what caused this)
- Not every `ConfigureRequest` event has a corresponding `LogRequest` event. I was seeing, on app initialization, about 14 duplicate timings for the same request. To address this I just added a simple marker using a property bag RavenDB associates with each request passed around.
- **Not Solved**: Simultaneous requests might accidentally write to separate HttpContexts, I believe due to how the event is being fired. Still investigating a fix.