### PR TITLE
Protect against NullReferenceExceptions when Load() returns a null profiler

### DIFF
--- a/StackExchange.Profiling/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/MiniProfilerHandler.cs
@@ -260,6 +260,12 @@ namespace StackExchange.Profiling
                 g =>
                 {
                     var profiler = MiniProfiler.Settings.Storage.Load(g);
+                    
+                    if (profiler == null)
+                    {
+                        return null;
+                    }
+                    
                     return new
                     {
                         profiler.Id,
@@ -271,7 +277,7 @@ namespace StackExchange.Profiling
                         profiler.User,
                         profiler.DurationMilliseconds
                     };
-                }).ToJson();
+                }).Where(x => x != null).ToJson();
         }
 
         /// <summary>


### PR DESCRIPTION
There is a race condition where getting the list of profiler GUIDs would return a valid id but then loading the profiler by id it might not exist. This causes NullRefereneceExceptions. For example, we have our own Redis storage implementation where profilers automatically expire after a specified timeout.

So, depending on the storage, profilers might not exist by id and this protects against that.