### PR TITLE
Make use of AuthorizeRequest to ensure a 401 status code for single profiler result

### DIFF
--- a/StackExchange.Profiling/MiniProfilerHandler.cs
+++ b/StackExchange.Profiling/MiniProfilerHandler.cs
@@ -332,8 +332,8 @@ namespace StackExchange.Profiling
                 MiniProfiler.Settings.Storage.Save(profiler);
             }
 
-            var authorize = MiniProfiler.Settings.Results_Authorize;
-            if (authorize != null && !authorize(context.Request))
+            string authorizeMessage;
+            if (!AuthorizeRequest(context, isList: false, message: out authorizeMessage))
             {
                 context.Response.ContentType = "application/json";
                 return "hidden".ToJson();


### PR DESCRIPTION
If a non-authorized user visits a MiniProfiler results url (e.g. `http://app.com/mini-profiler-resources/results?id=<guid>`), they do *not* get a 401 status code. Having a 401 status code is what the documentation for `MiniProfiler.Settings.Results_Authorize` says it should return.