### PR TITLE
async multithreading support

### DIFF
--- a/src/MiniProfiler.Providers.SqlServer/SqlServerStorage.cs
+++ b/src/MiniProfiler.Providers.SqlServer/SqlServerStorage.cs
@@ -85,15 +85,17 @@ where not exists (select 1 from MiniProfilers where Id = @Id)"; // this syntax w
                 }
 
                 SaveTimings(timings, conn);
-                if (profiler.ClientTimings != null && profiler.ClientTimings.Timings != null && profiler.ClientTimings.Timings.Any())
+
+                var clientTimings = profiler.ClientTimings?.Timings;
+                if (clientTimings != null && clientTimings.Any())
                 {
                     // set the profilerId (isn't needed unless we are storing it)
-                    profiler.ClientTimings.Timings.ForEach(x =>
+                    foreach(var x in clientTimings)
                     {
                         x.MiniProfilerId = profiler.Id;
                         x.Id = Guid.NewGuid();
-                    });
-                    SaveClientTimings(profiler.ClientTimings.Timings, conn);
+                    }
+                    SaveClientTimings(clientTimings, conn);
                 }
             }
         }
@@ -139,7 +141,7 @@ WHERE NOT EXISTS (SELECT 1 FROM MiniProfilerTimings WHERE Id = @Id)";
             }
         }
 
-        private void SaveClientTimings(List<ClientTiming> timings, DbConnection conn)
+        private void SaveClientTimings(IReadOnlyList<ClientTiming> timings, DbConnection conn)
         {
             const string sql = @"
 INSERT INTO MiniProfilerClientTimings

--- a/src/MiniProfiler.Providers.SqlServerCe/SqlServerCeStorage.cs
+++ b/src/MiniProfiler.Providers.SqlServerCe/SqlServerCeStorage.cs
@@ -86,15 +86,16 @@ where not exists (select 1 from MiniProfilers where Id = @Id)"; // this syntax w
                 }
 
                 SaveTimings(timings, conn);
-                if (profiler.ClientTimings != null && profiler.ClientTimings.Timings != null && profiler.ClientTimings.Timings.Any())
+                var clientTimings = profiler.ClientTimings?.Timings;
+                if (clientTimings != null && clientTimings.Any())
                 {
                     // set the profilerId (isn't needed unless we are storing it)
-                    profiler.ClientTimings.Timings.ForEach(x =>
+                    foreach (var x in clientTimings)
                     {
                         x.MiniProfilerId = profiler.Id;
                         x.Id = Guid.NewGuid();
-                    });
-                    SaveClientTimings(profiler.ClientTimings.Timings, conn);
+                    }
+                    SaveClientTimings(clientTimings, conn);
                 }
             }
         }
@@ -140,7 +141,7 @@ WHERE NOT EXISTS (SELECT 1 FROM MiniProfilerTimings WHERE Id = @Id)";
             }
         }
 
-        private void SaveClientTimings(List<ClientTiming> timings, DbConnection conn)
+        private void SaveClientTimings(IReadOnlyList<ClientTiming> timings, DbConnection conn)
         {
             const string sql = @"
 INSERT INTO MiniProfilerClientTimings

--- a/src/MiniProfiler.Shared/ClientTimings.cs
+++ b/src/MiniProfiler.Shared/ClientTimings.cs
@@ -14,12 +14,26 @@ namespace StackExchange.Profiling
     {
         private const string TimingPrefix = "clientPerformance[timing][";
         private const string ProbesPrefix = "clientProbes[";
+        private readonly object _lockObject = new object();
+        private List<ClientTiming> _timings;
 
         /// <summary>
         /// Gets or sets the list of client side timings
         /// </summary>
         [DataMember(Order = 2)]
-        public List<ClientTiming> Timings { get; set; }
+        public List<ClientTiming> Timings
+        {
+            get
+            {
+                lock(_lockObject)
+                    return _timings == null ? null : new List<ClientTiming>(_timings);
+            }
+            set
+            {
+                lock (_lockObject)
+                    _timings = value == null ? null : new List<ClientTiming>(value);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the redirect count.

--- a/src/MiniProfiler.Shared/Helpers/Net45/AsyncLocal.cs
+++ b/src/MiniProfiler.Shared/Helpers/Net45/AsyncLocal.cs
@@ -1,0 +1,78 @@
+﻿#if NET45
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Messaging;
+using System.Runtime.Serialization;
+
+namespace StackExchange.Profiling.Helpers.Net45
+{
+    /// <summary>
+    /// Implements interface similar to AsyncLocal which is not available until .Net 4.6.
+    /// 
+    /// The implementation is inspired by Ambient Context Logic from here: 
+    /// https://github.com/mehdime/DbContextScope/blob/master/Mehdime.Entity/Implementations/DbContextScope.cs
+    /// Unlike DbContextScope's implementation this implementation doesn't support serialization/deserialization 
+    /// ths not allowing to cross app domain barrier.
+    /// </summary>
+    internal class AsyncLocal<T>
+    where T : class
+    {
+        public AsyncLocal()
+        {
+        }
+
+        public AsyncLocal(
+            T obj
+            )
+        {
+            Value = obj;
+        }
+
+        /// <summary>
+        /// Gets or Sets the value.
+        /// </summary>
+        public T Value
+        {
+            get
+            {
+                return (CallContext.LogicalGetData(_id) as ObjectRef)?.Ref;
+            }
+
+            set
+            {
+                CallContext.LogicalSetData(_id, new ObjectRef { Ref = value });
+            }
+        }
+
+        /// <summary>
+        /// Identifies this instance of <see cref="AsyncLocal"/> in CallContext.
+        /// </summary>
+        private readonly string _id = Guid.NewGuid().ToString();
+
+        [Serializable]
+        private class ObjectRef : MarshalByRefObject, ISerializable
+        {
+            // The special constructor is used to deserialize values.
+            public ObjectRef()
+            {
+            }
+
+            // The special constructor is used to deserialize values.
+            public ObjectRef(
+                SerializationInfo info,
+                StreamingContext context
+                )
+            {
+            }
+
+            public void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+            }
+
+            public T Ref { get; set; }
+        }
+    }
+}
+#endif

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyName>MiniProfiler.Shared</AssemblyName>

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />

--- a/src/MiniProfiler.Shared/MiniProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.cs
@@ -135,10 +135,9 @@ namespace StackExchange.Profiling
                     {
                         var timing = timings.Pop();
 
-                        if (timing.HasChildren)
+                        var children = timing.Children;
+                        if (children?.Count > 0)
                         {
-                            var children = timing.Children;
-
                             for (int i = children.Count - 1; i >= 0; i--)
                             {
                                 children[i].ParentTiming = timing;
@@ -189,7 +188,19 @@ namespace StackExchange.Profiling
         /// <summary>
         /// Gets or sets points to the currently executing Timing. 
         /// </summary>
-        public Timing Head { get; set; }
+        public Timing Head
+        {
+            get
+            {
+                Settings.EnsureProfilerProvider();
+                return Settings.ProfilerProvider.CurrentHead;
+            }
+            set
+            {
+                Settings.EnsureProfilerProvider();
+                Settings.ProfilerProvider.CurrentHead = value;
+            }
+        }
 
         /// <summary>
         /// Gets the ticks since this MiniProfiler was started.
@@ -329,9 +340,9 @@ namespace StackExchange.Profiling
 
                 yield return timing;
 
-                if (timing.HasChildren)
+                var children = timing.Children;
+                if (children?.Count > 0)
                 {
-                    var children = timing.Children;
                     for (int i = children.Count - 1; i >= 0; i--) timings.Push(children[i]);
                 }
             }

--- a/src/MiniProfiler.Shared/ProfileProviders/BaseProfilerProvider.cs
+++ b/src/MiniProfiler.Shared/ProfileProviders/BaseProfilerProvider.cs
@@ -29,6 +29,11 @@ namespace StackExchange.Profiling
         public abstract MiniProfiler GetCurrentProfiler();
 
         /// <summary>
+        /// GEts or sets the current head timing. This is used by <see cref="MiniProfiler.Head"/>.
+        /// </summary>
+        public abstract Timing CurrentHead { get; set; }
+
+        /// <summary>
         /// Sets <paramref name="profiler"/> to be active (read to start profiling)
         /// This should be called once a new MiniProfiler has been created.
         /// </summary>

--- a/src/MiniProfiler.Shared/ProfileProviders/DefaultProfilerProvider.cs
+++ b/src/MiniProfiler.Shared/ProfileProviders/DefaultProfilerProvider.cs
@@ -1,7 +1,8 @@
 ﻿#if NET45
 using System;
 using System.Runtime.Remoting.Messaging;
-using System.Web;
+using System.Web; 
+using StackExchange.Profiling.Helpers.Net45;
 #else
 using System.Threading;
 #endif
@@ -13,43 +14,23 @@ namespace StackExchange.Profiling
     /// </summary>
     public class DefaultProfilerProvider : BaseProfilerProvider
     {
-#if NET45
-        const string ContextKey = ":miniprofiler:";
-
-        private MiniProfiler Profiler
-        {
-            get
-            {
-                if (HttpContext.Current != null)
-                {
-                    return HttpContext.Current?.Items[ContextKey] as MiniProfiler;
-                }
-                else
-                {
-                    return CallContext.LogicalGetData(ContextKey) as MiniProfiler;
-                }
-            }
-            set
-            {
-                if (HttpContext.Current != null)
-                {
-                    HttpContext.Current.Items[ContextKey] = value;
-                }
-                else
-                {
-                    CallContext.LogicalSetData(ContextKey, value);
-                }
-            }
-        }
-#else
-        private AsyncLocal<MiniProfiler> _profiler = new AsyncLocal<MiniProfiler>();
+        private readonly AsyncLocal<MiniProfiler> _profiler = new AsyncLocal<MiniProfiler>();
+        private readonly AsyncLocal<Timing> _currentTiming = new AsyncLocal<Timing>();
 
         private MiniProfiler Profiler
         {
             get { return _profiler.Value; }
             set { _profiler.Value = value; }
         }
-#endif
+
+        /// <summary>
+        /// Current head timing.
+        /// </summary>
+        public override Timing CurrentHead
+        {
+            get { return _currentTiming.Value; }
+            set { _currentTiming.Value = value; }
+        }
 
         /// <summary>
         /// The name says it all.

--- a/src/MiniProfiler.Shared/ProfileProviders/IProfilerProvider.cs
+++ b/src/MiniProfiler.Shared/ProfileProviders/IProfilerProvider.cs
@@ -30,5 +30,10 @@ namespace StackExchange.Profiling
         /// Returns the current MiniProfiler.  This is used by <see cref="MiniProfiler.Current"/>.
         /// </summary>
         MiniProfiler GetCurrentProfiler();
+
+        /// <summary>
+        /// Current head <see cref="Timing"/>. Used by <see cref="MiniProfiler.Head"/>
+        /// </summary>
+        Timing CurrentHead { get; set; }
     }
 }

--- a/src/MiniProfiler.Shared/ProfileProviders/SingletonProfilerProvider.cs
+++ b/src/MiniProfiler.Shared/ProfileProviders/SingletonProfilerProvider.cs
@@ -9,11 +9,21 @@ namespace StackExchange.Profiling
     public class SingletonProfilerProvider : IProfilerProvider
     {
         private MiniProfiler _profiler;
+        private Timing _timing;
 
         /// <summary>
         /// The name says it all
         /// </summary>
         public MiniProfiler GetCurrentProfiler() => _profiler;
+
+        /// <summary>
+        /// Current head timing.
+        /// </summary>
+        public Timing CurrentHead
+        {
+            get { return _timing; }
+            set { _timing = value; }
+        }
 
         /// <summary>
         /// Starts a new profiling session.

--- a/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
+++ b/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
@@ -132,9 +132,13 @@ namespace StackExchange.Profiling.Storage
         protected void FlattenTimings(Timing timing, List<Timing> timingsCollection)
         {
             timingsCollection.Add(timing);
-            if (timing.HasChildren)
+            var children = timing.Children;
+            if (children?.Count > 0)
             {
-                timing.Children?.ForEach(x => FlattenTimings(x, timingsCollection));
+                foreach (var child in children)
+                {
+                    FlattenTimings(child, timingsCollection);
+                }
             }
         }
     }

--- a/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
+++ b/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
@@ -134,7 +134,7 @@ namespace StackExchange.Profiling.Storage
             timingsCollection.Add(timing);
             if (timing.HasChildren)
             {
-                timing.Children.ForEach(x => FlattenTimings(x, timingsCollection));
+                timing.Children?.ForEach(x => FlattenTimings(x, timingsCollection));
             }
         }
     }

--- a/src/MiniProfiler.Shared/Timing.cs
+++ b/src/MiniProfiler.Shared/Timing.cs
@@ -78,13 +78,13 @@ namespace StackExchange.Profiling
         /// Gets or sets All sub-steps that occur within this Timing step. Add new children through <see cref="AddChild"/>
         /// </summary>
         [DataMember(Order = 5)]
-        public IImmutableList<Timing> Children
+        public List<Timing> Children
         {
             get
             {
                 lock(_lockObject)
                 {
-                    return _children == null ? (IImmutableList<Timing>)null : new List<Timing>(_children).ToImmutableArray();
+                    return _children == null ? null : new List<Timing>(_children);
                 }
             }
             set

--- a/src/MiniProfiler.Shared/Timing.cs
+++ b/src/MiniProfiler.Shared/Timing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using StackExchange.Profiling.Helpers;
+using System.Collections.Immutable;
 #if NET45
 using System.Web.Script.Serialization;
 #endif
@@ -77,13 +78,13 @@ namespace StackExchange.Profiling
         /// Gets or sets All sub-steps that occur within this Timing step. Add new children through <see cref="AddChild"/>
         /// </summary>
         [DataMember(Order = 5)]
-        public List<Timing> Children
+        public IImmutableList<Timing> Children
         {
             get
             {
                 lock(_lockObject)
                 {
-                    return _children == null ? null : new List<Timing>(_children);
+                    return _children == null ? (IImmutableList<Timing>)null : new List<Timing>(_children).ToImmutableArray();
                 }
             }
             set

--- a/src/MiniProfiler/MiniProfilerWebExtensions.cs
+++ b/src/MiniProfiler/MiniProfilerWebExtensions.cs
@@ -93,10 +93,10 @@ namespace StackExchange.Profiling
                 }
 
                 text.AppendLine();
-                
-                if (timing.HasChildren)
+
+                var children = timing.Children;
+                if (children?.Count > 0)
                 {
-                    var children = timing.Children;
                     for (var i = children.Count - 1; i >= 0; i--) timings.Push(children[i]);
                 }
             }

--- a/src/MiniProfiler/MiniProfilerWebExtensions.cs
+++ b/src/MiniProfiler/MiniProfilerWebExtensions.cs
@@ -76,9 +76,10 @@ namespace StackExchange.Profiling
 
                 text.AppendFormat("{2} {0} = {1:###,##0.##}ms", name, timing.DurationMilliseconds, new string('>', timing.Depth));
 
-                if (timing.HasCustomTimings)
+                var customTimingsMap = timing.CustomTimings;
+                if (customTimingsMap?.Count > 0)
                 {
-                    foreach (var pair in timing.CustomTimings)
+                    foreach (var pair in customTimingsMap)
                     {
                         var type = pair.Key;
                         var customTimings = pair.Value;

--- a/src/MiniProfiler/ProfileProviders/WebRequestProfilerProvider.cs
+++ b/src/MiniProfiler/ProfileProviders/WebRequestProfilerProvider.cs
@@ -150,7 +150,23 @@ namespace StackExchange.Profiling
         /// </summary>
         public override MiniProfiler GetCurrentProfiler() => Current;
 
+        /// <summary>
+        /// Current head timing.
+        /// </summary>
+        public override Timing CurrentHead
+        {
+            get { return HttpContext.Current?.Items[CacheKeyHead] as Timing; }
+            set
+            {
+                var context = HttpContext.Current;
+                if (context == null) return;
+
+                context.Items[CacheKeyHead] = value;
+            }
+        }
+
         private const string CacheKey = ":mini-profiler:";
+        private const string CacheKeyHead = ":mini-profiler-head:";
 
         /// <summary>
         /// Gets the currently running MiniProfiler for the current HttpContext; null if no MiniProfiler was <see cref="Start(string)"/>ed.

--- a/tests/MiniProfiler.Tests/App.config
+++ b/tests/MiniProfiler.Tests/App.config
@@ -34,4 +34,7 @@
       <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
     </DbProviderFactories>
   </system.data>
+  <appSettings>
+    <add key="xunit.parallelizeTestCollections" value="false"/>
+  </appSettings>
 </configuration>

--- a/tests/MiniProfiler.Tests/BaseTest.cs
+++ b/tests/MiniProfiler.Tests/BaseTest.cs
@@ -173,7 +173,7 @@ namespace StackExchange.Profiling.Tests
             // we'll handle any collections elsewhere
             var props = from p in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
                         where p.IsDefined(typeof(System.Runtime.Serialization.DataMemberAttribute), false)
-                        && !p.PropertyType.GetInterfaces().Any(i => i.Equals(typeof(IDictionary)) || i.Equals(typeof(IList)))
+                        && !p.PropertyType.GetInterfaces().Any(i => i.Equals(typeof(IEnumerable)))
                         select p;
 
             foreach (var p in props)

--- a/tests/MiniProfiler.Tests/MiniProfilerTest.cs
+++ b/tests/MiniProfiler.Tests/MiniProfilerTest.cs
@@ -153,8 +153,8 @@ namespace StackExchange.Profiling.Tests
                 }
                 MiniProfiler.Stop();
 
-                Assert.True(mp1.Root.Children.ToList().Contains(goodTiming));
-                Assert.True(!mp1.Root.Children.ToList().Contains(badTiming));
+                Assert.True(mp1.Root.Children.Contains(goodTiming));
+                Assert.True(!mp1.Root.Children.Contains(badTiming));
             }
         }
 

--- a/tests/MiniProfiler.Tests/MiniProfilerTest.cs
+++ b/tests/MiniProfiler.Tests/MiniProfilerTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace StackExchange.Profiling.Tests
@@ -32,6 +34,102 @@ namespace StackExchange.Profiling.Tests
             }
         }
 
+        [Fact]
+        public void WhenUsingAsyncProvider_SimpleCaseWorking()
+        {
+            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
+            using (GetRequest())
+            {
+                MiniProfiler.Start();
+                IncrementStopwatch(); // 1 ms
+                MiniProfiler.Stop();
+
+                var c = MiniProfiler.Current;
+
+                Assert.NotNull(c);
+                Assert.Equal(StepTimeMilliseconds, c.DurationMilliseconds);
+
+                Assert.NotNull(c.Root);
+                Assert.False(c.Root.HasChildren);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Current_WhenAsyncMethodReturns_IsCarried(
+            bool configureAwait
+            )
+        {
+            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
+            using (GetRequest())
+            {
+                MiniProfiler.Start();
+
+                var c = MiniProfiler.Current;
+                await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(configureAwait);
+
+                Assert.NotNull(MiniProfiler.Current);
+                Assert.Equal(c, MiniProfiler.Current);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Head_WhenAsyncMethodReturns_IsCarried(
+            bool configureAwait
+            )
+        {
+            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
+            using (GetRequest())
+            {
+                MiniProfiler.Start();
+                var sut = MiniProfiler.Current;
+                var head = sut.Head;
+
+                await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(configureAwait);
+
+                Assert.NotNull(sut.Head);
+                Assert.Equal(head, sut.Head);
+            }
+        }
+
+        [Fact]
+        public void Head_WhenMultipleTasksSpawned_EachSetsItsOwnHead()
+        {
+            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
+            var allTasks = new SemaphoreSlim(0, 1);
+            var completed = new TaskCompletionSource<int>();
+            using (GetRequest("http://localhost/Test.aspx", startAndStopProfiler: false))
+            {
+                MiniProfiler.Start();
+                var sut = MiniProfiler.Current;
+                var head = sut.Head;
+
+                Task.Run(() => {
+                    Assert.Equal(head, sut.Head);
+                    using (sut.Step("test1"))
+                    {
+                        allTasks.Release();
+                        completed.Task.Wait();
+                    }
+                });
+                allTasks.Wait();
+                Task.Run(() => {
+                    using (sut.Step("test2"))
+                    {
+                        allTasks.Release();
+                        completed.Task.Wait();
+                    }
+                });
+                allTasks.Wait();
+
+                Assert.NotNull(sut.Head);
+                Assert.Equal(head, sut.Head);
+                completed.SetResult(0);
+            }
+        }
         [Fact]
         public void StepIf_Basic()
         {

--- a/tests/MiniProfiler.Tests/MiniProfilerTest.cs
+++ b/tests/MiniProfiler.Tests/MiniProfilerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -152,8 +153,8 @@ namespace StackExchange.Profiling.Tests
                 }
                 MiniProfiler.Stop();
 
-                Assert.True(mp1.Root.Children.Contains(goodTiming));
-                Assert.True(!mp1.Root.Children.Contains(badTiming));
+                Assert.True(mp1.Root.Children.ToList().Contains(goodTiming));
+                Assert.True(!mp1.Root.Children.ToList().Contains(badTiming));
             }
         }
 

--- a/tests/MiniProfiler.Tests/Storage/SqlServerStorageTest.cs
+++ b/tests/MiniProfiler.Tests/Storage/SqlServerStorageTest.cs
@@ -16,6 +16,7 @@ namespace StackExchange.Profiling.Tests.Storage
         
         public SqlServerStorageTest(SqlCeStorageFixture<SqlServerStorageTest> fixture)
         {
+            MiniProfiler.Settings.ProfilerProvider = new WebRequestProfilerProvider();
             _conn = fixture.Conn;
         }
         


### PR DESCRIPTION
This is my attempt to improve multithreading support for miniprofiler v4. I think the current version of the mini profiler would have issues in scenarios where the current thread spawns more than one task and waits for them.
```
        [Fact]
        public void Head_WhenMultipleTasksSpawned_EachSetsItsOwnHead()
        {
            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
            var allTasks = new SemaphoreSlim(0, 1);
            var completed = new TaskCompletionSource<int>();
            using (GetRequest("http://localhost/Test.aspx", startAndStopProfiler: false))
            {
                MiniProfiler.Start();
                var sut = MiniProfiler.Current;
                var head = sut.Head;

                Task.Run(() => {
                    Assert.Equal(head, sut.Head);
                    using (sut.Step("test1"))
                    {
                        allTasks.Release();
                        completed.Task.Wait();
                    }
                });
                allTasks.Wait();
                Task.Run(() => {
                    using (sut.Step("test2"))
                    {
                        allTasks.Release();
                        completed.Task.Wait();
                    }
                });
                allTasks.Wait();

                Assert.NotNull(sut.Head);
                Assert.Equal(head, sut.Head);
                completed.SetResult(0);
            }
        }
```
In this scenario there would be multiple threads working with the mini profiler (since they would share it via AsyncLocal). This could lead to random failures since Timing class is not thread safe. Also this could lead to inconsistencies since the spawned tasks would replace the Head timing for the mini profiler instance, with one of the tasks's timing potentially becoming a child of another's. 