### PR TITLE
Specify StringComparison when calling string.StartsWith/EndsWith/IndexOf

### DIFF
--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -47,8 +47,8 @@ namespace StackExchange.Profiling
 
             var basePath = Options.RouteBasePath;
             // Example transform: ~/mini-profiler-results/ to /mini-profiler-results
-            if (basePath.StartsWith("~/")) basePath = basePath.Substring(1);
-            if (basePath.EndsWith("/") && basePath.Length > 2) basePath = basePath.Substring(0, basePath.Length - 1);
+            if (basePath.StartsWith("~/", StringComparison.Ordinal)) basePath = basePath.Substring(1);
+            if (basePath.EndsWith("/", StringComparison.Ordinal) && basePath.Length > 2) basePath = basePath.Substring(0, basePath.Length - 1);
 
             BasePath = new PathString(basePath);
             Embedded = new EmbeddedProvider(Options, _env);
@@ -143,7 +143,7 @@ namespace StackExchange.Profiling
             string result = null;
 
             // File embed
-            if (subPath.Value.StartsWith("/includes"))
+            if (subPath.Value.StartsWith("/includes", StringComparison.Ordinal))
             {
                 result = Embedded.GetFile(context, subPath);
             }

--- a/src/MiniProfiler.Shared/ClientTimings.cs
+++ b/src/MiniProfiler.Shared/ClientTimings.cs
@@ -51,7 +51,7 @@ namespace StackExchange.Profiling
                         form.Keys.Cast<string>()
                                .OrderBy(i => i.IndexOf("Start]", StringComparison.Ordinal) > 0 ? "_" + i : i))
                 {
-                    if (key.StartsWith(TimingPrefix))
+                    if (key.StartsWith(TimingPrefix, StringComparison.Ordinal))
                     {
                         long.TryParse(form[key], out long val);
                         val -= navigationStart;
@@ -62,7 +62,7 @@ namespace StackExchange.Profiling
                         // just ignore stuff that is negative ... not relevant
                         if (val > 0)
                         {
-                            if (parsedName.EndsWith("Start"))
+                            if (parsedName.EndsWith("Start", StringComparison.Ordinal))
                             {
                                 var shortName = parsedName.Substring(0, parsedName.Length - 5);
                                 clientPerf[shortName] = new ClientTiming
@@ -72,7 +72,7 @@ namespace StackExchange.Profiling
                                     Start = val
                                 };
                             }
-                            else if (parsedName.EndsWith("End"))
+                            else if (parsedName.EndsWith("End", StringComparison.Ordinal))
                             {
                                 var shortName = parsedName.Substring(0, parsedName.Length - 3);
                                 if (clientPerf.TryGetValue(shortName, out var t))
@@ -88,7 +88,7 @@ namespace StackExchange.Profiling
                         }
                     }
 
-                    if (key.StartsWith(ProbesPrefix))
+                    if (key.StartsWith(ProbesPrefix, StringComparison.Ordinal))
                     {
                         if (key.IndexOf("]", StringComparison.Ordinal) > 0 && int.TryParse(key.Substring(ProbesPrefix.Length, key.IndexOf("]", StringComparison.Ordinal) - ProbesPrefix.Length), out int probeId))
                         {
@@ -98,12 +98,12 @@ namespace StackExchange.Profiling
                                 clientProbes.Add(probeId, t);
                             }
 
-                            if (key.EndsWith("[n]"))
+                            if (key.EndsWith("[n]", StringComparison.Ordinal))
                             {
                                 t.Name = form[key];
                             }
 
-                            if (key.EndsWith("[d]"))
+                            if (key.EndsWith("[d]", StringComparison.Ordinal))
                             {
                                 long.TryParse(form[key], out long val);
                                 if (val > 0)

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -100,10 +100,10 @@ namespace StackExchange.Profiling.SqlFormatters
         }
 
         private string EnsureParameterPrefix(string name) =>
-            !name.StartsWith("@") ? "@" + name : name;
+            !name.StartsWith("@", StringComparison.Ordinal) ? "@" + name : name;
 
         private string RemoveParameterPrefix(string name) =>
-            name.StartsWith("@") ? name.Substring(1) : name;
+            name.StartsWith("@", StringComparison.Ordinal) ? name.Substring(1) : name;
 
         private void GenerateStoreProcedureCall(string commandText, List<SqlTimingParameter> parameters, StringBuilder buffer)
         {

--- a/tests/MiniProfiler.Tests/Async/AsyncTests.cs
+++ b/tests/MiniProfiler.Tests/Async/AsyncTests.cs
@@ -186,12 +186,12 @@ namespace Tests.Async
             var hierarchy = profiler.GetTimingHierarchy().ToList();
             foreach (var timing in hierarchy)
             {
-                if (timing.Name.StartsWith("thread"))
+                if (timing.Name.StartsWith("thread", StringComparison.Ordinal))
                 {
                     // 3 work items, 50 ms each
                     AssertNear(500, timing.DurationMilliseconds, 100);
                 }
-                else if (timing.Name.StartsWith("work"))
+                else if (timing.Name.StartsWith("work", StringComparison.Ordinal))
                 {
                     // 50 ms each work item
                     AssertNear(50, timing.DurationMilliseconds, 20);

--- a/tests/MiniProfiler.Tests/lib/HaackHttpSimulator/HttpSimulator.cs
+++ b/tests/MiniProfiler.Tests/lib/HaackHttpSimulator/HttpSimulator.cs
@@ -360,7 +360,7 @@ namespace Subtext.TestLibrary
             if (searchIndex < 0)
                 return original;
 
-            return original.Substring(original.IndexOf(search) + search.Length);
+            return original.Substring(original.IndexOf(search, 0, StringComparison.Ordinal) + search.Length);
         }
 
         public string Host => host;
@@ -429,7 +429,7 @@ namespace Subtext.TestLibrary
         private static string ExtractQueryStringPart(Uri url)
         {
             string query = url.Query ?? string.Empty;
-            if (query.StartsWith("?"))
+            if (query.StartsWith("?", StringComparison.Ordinal))
                 return query.Substring(1);
             return query;
         }


### PR DESCRIPTION
`string.StartsWith`/`EndsWith`/`IndexOf` do a culture-sensitive comparison by default, which could result in different behavior depending on the `CurrentCulture`. These comparisons should be `Ordinal`.