### PR TITLE
Remove unnecessary `Cast<string>()`

### DIFF
--- a/src/MiniProfiler.Shared/ClientTimings.cs
+++ b/src/MiniProfiler.Shared/ClientTimings.cs
@@ -48,8 +48,7 @@ namespace StackExchange.Profiling
                 var clientProbes = new Dictionary<int, ClientTiming>();
 
                 foreach (string key in
-                        form.Keys.Cast<string>()
-                               .OrderBy(i => i.IndexOf("Start]", StringComparison.Ordinal) > 0 ? "_" + i : i))
+                        form.Keys.OrderBy(i => i.IndexOf("Start]", StringComparison.Ordinal) > 0 ? "_" + i : i))
                 {
                     if (key.StartsWith(TimingPrefix))
                     {


### PR DESCRIPTION
`form.Keys` is already `ICollection<string>`, there's no need to cast.