### PR TITLE
Use IndexOf(char) where appropriate

### DIFF
--- a/src/MiniProfiler.Shared/ClientTimings.cs
+++ b/src/MiniProfiler.Shared/ClientTimings.cs
@@ -90,7 +90,8 @@ namespace StackExchange.Profiling
 
                     if (key.StartsWith(ProbesPrefix))
                     {
-                        if (key.IndexOf("]", StringComparison.Ordinal) > 0 && int.TryParse(key.Substring(ProbesPrefix.Length, key.IndexOf("]", StringComparison.Ordinal) - ProbesPrefix.Length), out int probeId))
+                        int endBracketIndex = key.IndexOf(']');
+                        if (endBracketIndex > 0 && int.TryParse(key.Substring(ProbesPrefix.Length, endBracketIndex - ProbesPrefix.Length), out int probeId))
                         {
                             if (!clientProbes.TryGetValue(probeId, out var t))
                             {


### PR DESCRIPTION
Calls to `IndexOf(string, StringComparison.Ordinal)` when `string` is a single char can be replaced with `IndexOf(char`) for slightly improved performance. Also, in this case, the search can be conducted once instead of twice.