### PR TITLE
Remove explicit static constructors

### DIFF
--- a/src/MiniProfiler.Shared/MiniProfiler.Settings.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.Settings.cs
@@ -43,12 +43,6 @@ namespace StackExchange.Profiling
                     ".ctor"
                 };
 
-            static Settings()
-            {
-                // for normal usage, this will return a System.Diagnostics.Stopwatch to collect times - unit tests can explicitly set how much time elapses
-                StopwatchProvider = StopwatchWrapper.StartNew;
-            }
-
             /// <summary>
             /// The path under which ALL routes are registered in, defaults to the application root.  For example, "~/myDirectory/" would yield
             /// "/myDirectory/includes.js" rather than just "/mini-profiler-resources/includes.js"
@@ -204,7 +198,7 @@ namespace StackExchange.Profiling
             /// <summary>
             /// Allows switching out stopwatches for unit testing.
             /// </summary>
-            public static Func<IStopwatch> StopwatchProvider { get; set; }
+            public static Func<IStopwatch> StopwatchProvider { get; set; } = StopwatchWrapper.StartNew;
         }
     }
 }

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -15,7 +15,22 @@ namespace StackExchange.Profiling.SqlFormatters
         /// <summary>
         /// Lookup a function for translating a parameter by parameter type
         /// </summary>
-        protected static readonly Dictionary<DbType, Func<SqlTimingParameter, string>> ParamTranslator;
+        protected static readonly Dictionary<DbType, Func<SqlTimingParameter, string>> ParamTranslator = new Dictionary<DbType, Func<SqlTimingParameter, string>>
+        {
+            [DbType.AnsiString] = GetWithLenFormatter("varchar"),
+            [DbType.String] = GetWithLenFormatter("nvarchar"),
+            [DbType.AnsiStringFixedLength] = GetWithLenFormatter("char"),
+            [DbType.StringFixedLength] = GetWithLenFormatter("nchar"),
+            [DbType.Byte] = p => "tinyint",
+            [DbType.Int16] = p => "smallint",
+            [DbType.Int32] = p => "int",
+            [DbType.Int64] = p => "bigint",
+            [DbType.DateTime] = p => "datetime",
+            [DbType.Guid] = p => "uniqueidentifier",
+            [DbType.Boolean] = p => "bit",
+            [DbType.Binary] = GetWithLenFormatter("varbinary"),
+        };
+
         /// <summary>
         /// What data types should not be quoted when used in parameters
         /// </summary>
@@ -32,28 +47,6 @@ namespace StackExchange.Profiling.SqlFormatters
                         return capture;
                     return capture + "(" + (p.Size > 8000 ? "max" : p.Size.ToString(CultureInfo.InvariantCulture)) + ")";
                 };
-        }
-
-        /// <summary>
-        /// Initialises static members of the <see cref="SqlServerFormatter"/> class.
-        /// </summary>
-        static SqlServerFormatter()
-        {
-            ParamTranslator = new Dictionary<DbType, Func<SqlTimingParameter, string>>
-            {
-                [DbType.AnsiString] = GetWithLenFormatter("varchar"),
-                [DbType.String] = GetWithLenFormatter("nvarchar"),
-                [DbType.AnsiStringFixedLength] = GetWithLenFormatter("char"),
-                [DbType.StringFixedLength] = GetWithLenFormatter("nchar"),
-                [DbType.Byte] = p => "tinyint",
-                [DbType.Int16] = p => "smallint",
-                [DbType.Int32] = p => "int",
-                [DbType.Int64] = p => "bigint",
-                [DbType.DateTime] = p => "datetime",
-                [DbType.Guid] = p => "uniqueidentifier",
-                [DbType.Boolean] = p => "bit",
-                [DbType.Binary] = GetWithLenFormatter("varbinary"),
-            };
         }
 
         /// <summary>


### PR DESCRIPTION
Explicit static cctors cause the C# compiler to not mark types as beforefieldinit, which means the JIT will add checks to each static method and instance constructors of the type to make sure that the static constructor was previously called. This can be avoided by removing explicit static constructors and initializing static fields inline.

See https://msdn.microsoft.com/en-us/library/ms182275.aspx for more info.