### PR TITLE
Use StringBuilder.Append(char) for single chars

### DIFF
--- a/src/MiniProfiler.Shared/Helpers/ExtensionMethods.cs
+++ b/src/MiniProfiler.Shared/Helpers/ExtensionMethods.cs
@@ -61,10 +61,10 @@ namespace StackExchange.Profiling.Helpers
             var sb = new StringBuilder("[");
             for (var i = 0; i < guids.Count; i++)
             {
-                sb.Append("\"").Append(guids[i]).Append("\"");
-                if (i < guids.Count - 1) sb.Append(",");
+                sb.Append('"').Append(guids[i]).Append('"');
+                if (i < guids.Count - 1) sb.Append(',');
             }
-            sb.Append("]");
+            sb.Append(']');
             return sb.ToString();
         }
 

--- a/src/MiniProfiler.Shared/Helpers/StackTraceSnippet.cs
+++ b/src/MiniProfiler.Shared/Helpers/StackTraceSnippet.cs
@@ -49,7 +49,7 @@ namespace StackExchange.Profiling.Helpers
                 {
                     if (sb.Length > 0)
                     {
-                        sb.Append(" ");
+                        sb.Append(' ');
                     }
                     sb.Append(method.Name);
                     stackLength += method.Name.Length + 1; // 1 added for spaces.

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -80,7 +80,7 @@ namespace StackExchange.Profiling.SqlFormatters
             {
                 GenerateParamText(buffer, parameters);
                 // finish the parameter declaration
-                buffer.Append(";")
+                buffer.Append(';')
                     .AppendLine()
                     .AppendLine();
             }
@@ -118,7 +118,7 @@ namespace StackExchange.Profiling.SqlFormatters
             buffer.Append(commandText);
 
             GenerateStoredProcedureParameters(buffer, parameters);
-            buffer.Append(";");
+            buffer.Append(';');
 
 	        GenerateSelectStatement(buffer, parameters);
         }
@@ -141,7 +141,7 @@ namespace StackExchange.Profiling.SqlFormatters
 
 		    if (parametersToSelect.Count == 0) return;
 
-			buffer.AppendLine().Append("SELECT ").Append(string.Join(", ", parametersToSelect)).Append(";");
+			buffer.AppendLine().Append("SELECT ").Append(string.Join(", ", parametersToSelect)).Append(';');
 	    }
 
 	    private static SqlTimingParameter GetReturnValueParameter(List<SqlTimingParameter> parameters)
@@ -159,7 +159,7 @@ namespace StackExchange.Profiling.SqlFormatters
         {
             if (sqlStatement[sqlStatement.Length - 1] != ';')
             {
-                sqlStatement.Append(";");
+                sqlStatement.Append(';');
             }
         }
 
@@ -177,11 +177,11 @@ namespace StackExchange.Profiling.SqlFormatters
 
                 if (!firstParameter)
                 {
-                    buffer.Append(",");
+                    buffer.Append(',');
                 }
 
                 firstParameter = false;
-                buffer.Append(" ").Append(EnsureParameterPrefix(parameter.Name)).Append(" = ").Append(EnsureParameterPrefix(parameter.Name));
+                buffer.Append(' ').Append(EnsureParameterPrefix(parameter.Name)).Append(" = ").Append(EnsureParameterPrefix(parameter.Name));
 
                 // Output and InputOutput directions treated equally on the database side.
                 if (parameter.Direction == ParameterDirection.Output.ToString()
@@ -232,7 +232,7 @@ namespace StackExchange.Profiling.SqlFormatters
 
                     var niceName = EnsureParameterPrefix(parameter.Name);
 
-                    buffer.Append(niceName).Append(" ").Append(resolvedType);
+                    buffer.Append(niceName).Append(' ').Append(resolvedType);
 
                     // return values don't have a value assignment
                     if (parameter.Direction != ParameterDirection.ReturnValue.ToString())

--- a/tests/MiniProfiler.Tests/lib/HaackHttpSimulator/SimulatedHttpRequest.cs
+++ b/tests/MiniProfiler.Tests/lib/HaackHttpSimulator/SimulatedHttpRequest.cs
@@ -134,7 +134,7 @@ namespace Subtext.TestLibrary
 
             foreach (string key in Form.Keys)
             {
-                sb.Append(key).Append("=").Append(Form[key]).Append("&");
+                sb.Append(key).Append('=').Append(Form[key]).Append('&');
             }
 
             return Encoding.UTF8.GetBytes(sb.ToString());


### PR DESCRIPTION
Slightly cheaper and in some cases slightly simpler code (e.g. `'"'` vs. `"\""`). Though, I wouldn't expect much of a measurable difference in these cases.