### PR TITLE
Use cached StringBuilder rather than StringBuilder.Replace

### DIFF
--- a/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
@@ -73,15 +73,10 @@ namespace StackExchange.Profiling
             var ids = state?.RequestIDs;
             if (ids != null)
             {
-                var first = true;
                 var length = ids.Count;
                 for (var i = 0; i < length; i++)
                 {
-                    if (first)
-                    {
-                        first = false;
-                    }
-                    else
+                    if (i > 0)
                     {
                         sb.Append(',');
                     }

--- a/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
-using StackExchange.Profiling.Helpers;
 using System;
-using System.Linq;
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace StackExchange.Profiling
@@ -14,6 +14,19 @@ namespace StackExchange.Profiling
     {
         // don't allocate this every time...
         private static readonly HtmlString includeNotFound = new HtmlString("<!-- Could not find 'include.partial.html' -->");
+
+        [ThreadStatic]
+        private static StringBuilder _stringBuilderCache;
+
+        private static StringBuilder GetStringBuilder() => _stringBuilderCache ?? CreateStringBuilder();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static StringBuilder CreateStringBuilder()
+        {
+            var sb = new StringBuilder();
+            _stringBuilderCache = sb;
+            return sb;
+        }
 
         /// <summary>
         /// Renders script tag found in "include.partial.html".
@@ -40,33 +53,76 @@ namespace StackExchange.Profiling
 
             // This is populated in Middleware by SetHeadersAndState
             var state = RequestState.Get(context);
+            var path = MiniProfilerMiddleware.Current.BasePath.Value;
+            var version = MiniProfiler.Settings.VersionHash;
 
-            // Is the user authroized to see the results of the current MiniProfiler?
-            var authorized = state?.IsAuthorized ?? false;
-            var ids = state?.RequestIDs ?? Enumerable.Empty<Guid>();
+            var sb = GetStringBuilder();
 
-            if (!MiniProfilerMiddleware.Current.Embedded.TryGetResource("include.partial.html", out string format))
+            sb.Append("<script async id=\"mini-profiler\" src=\"");
+            sb.Append(path);
+            sb.Append("includes.js?v=");
+            sb.Append(version);
+            sb.Append("\" data-version=\"");
+            sb.Append(version);
+            sb.Append("\" data-path=\"");
+            sb.Append(path);
+            sb.Append("\" data-current-id=\"");
+            sb.Append(profiler.Id.ToString());
+
+            sb.Append("\" data-ids=\"");
+            var ids = state?.RequestIDs;
+            if (ids != null)
             {
-                return includeNotFound;
+                var first = true;
+                var length = ids.Count;
+                for (var i = 0; i < length; i++)
+                {
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        sb.Append(',');
+                    }
+                    var id = ids[i];
+                    sb.Append(id.ToString());
+                }
             }
 
-            Func<bool, string> toJs = b => b ? "true" : "false";
+            sb.Append("\" data-position=\"");
+            sb.Append((position ?? MiniProfiler.Settings.PopupRenderPosition).ToString().ToLower());
 
-            var sb = new StringBuilder(format);
-            sb.Replace("{path}", MiniProfilerMiddleware.Current.BasePath.Value.EnsureTrailingSlash())
-              .Replace("{version}", MiniProfiler.Settings.VersionHash)
-              .Replace("{currentId}", profiler.Id.ToString())
-              .Replace("{ids}", string.Join(",", ids.Select(guid => guid.ToString())))
-              .Replace("{position}", (position ?? MiniProfiler.Settings.PopupRenderPosition).ToString().ToLower())
-              .Replace("{showTrivial}", toJs(showTrivial ?? MiniProfiler.Settings.PopupShowTrivial))
-              .Replace("{showChildren}", toJs(showTimeWithChildren ?? MiniProfiler.Settings.PopupShowTimeWithChildren))
-              .Replace("{maxTracesToShow}", (maxTracesToShow ?? MiniProfiler.Settings.PopupMaxTracesToShow).ToString())
-              .Replace("{showControls}", toJs(showControls ?? MiniProfiler.Settings.ShowControls))
-              .Replace("{authorized}", toJs(authorized))
-              .Replace("{toggleShortcut}", MiniProfiler.Settings.PopupToggleKeyboardShortcut)
-              .Replace("{startHidden}", toJs(startHidden ?? MiniProfiler.Settings.PopupStartHidden))
-              .Replace("{trivialMilliseconds}", MiniProfiler.Settings.TrivialDurationThresholdMilliseconds.ToString());
-            return new HtmlString(sb.ToString());
+            sb.Append("\" data-trivial=\"");
+            sb.Append((showTrivial ?? MiniProfiler.Settings.PopupShowTrivial) ? "true" : "false");
+
+            sb.Append("\" data-children=\"");
+            sb.Append((showTimeWithChildren ?? MiniProfiler.Settings.PopupShowTimeWithChildren) ? "true" : "false");
+
+            sb.Append("\" data-max-traces=\"");
+            sb.Append((maxTracesToShow ?? MiniProfiler.Settings.PopupMaxTracesToShow).ToString(CultureInfo.InvariantCulture));
+
+            sb.Append("\" data-controls=\"");
+            sb.Append((showControls ?? MiniProfiler.Settings.ShowControls) ? "true" : "false");
+
+            sb.Append("\" data-authorized=\"");
+            sb.Append((state?.IsAuthorized ?? false) ? "true" : "false");
+
+            sb.Append("\" data-toggle-shortcut=\"");
+            sb.Append(MiniProfiler.Settings.PopupToggleKeyboardShortcut);
+
+            sb.Append("\" data-start-hidden=\"");
+            sb.Append((startHidden ?? MiniProfiler.Settings.PopupStartHidden) ? "true" : "false");
+
+            sb.Append("\" data-trivial-milliseconds=\"");
+            sb.Append(MiniProfiler.Settings.TrivialDurationThresholdMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            sb.Append("\"></script>");
+
+            var htmlString = new HtmlString(sb.ToString());
+            // Clear StringBuilder for next use
+            sb.Length = 0;
+            return htmlString;
         }
     }
 }

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -19,6 +19,7 @@ namespace StackExchange.Profiling
         private readonly IHostingEnvironment _env;
 
         internal readonly PathString BasePath;
+        internal readonly PathString MatchPath;
         internal readonly MiniProfilerOptions Options;
         internal readonly EmbeddedProvider Embedded;
         internal static MiniProfilerMiddleware Current;
@@ -50,7 +51,8 @@ namespace StackExchange.Profiling
             if (basePath.StartsWith("~/", StringComparison.Ordinal)) basePath = basePath.Substring(1);
             if (basePath.EndsWith("/", StringComparison.Ordinal) && basePath.Length > 2) basePath = basePath.Substring(0, basePath.Length - 1);
 
-            BasePath = new PathString(basePath);
+            MatchPath = new PathString(basePath);
+            BasePath = new PathString(basePath.EnsureTrailingSlash());
             Embedded = new EmbeddedProvider(Options, _env);
             // A static reference back to this middleware for property access.
             // Which is probably a crime against humanity in ways I'm ignorant of.
@@ -70,7 +72,7 @@ namespace StackExchange.Profiling
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (context.Request.Path.StartsWithSegments(BasePath, out PathString subPath))
+            if (context.Request.Path.StartsWithSegments(MatchPath, out PathString subPath))
             {
                 // This is a request in the MiniProfiler path (e.g. one of "our" routes), HANDLE THE SITUATION.
                 await HandleRequest(context, subPath).ConfigureAwait(false);


### PR DESCRIPTION
Bit uglier but sb.Replace was sky high on the execution

Before
![before](https://aoa.blob.core.windows.net/aspnet/renderincludes.png)

After
![after](https://aoa.blob.core.windows.net/aspnet/renderincludes-2.png)