### PR TITLE
Add MySQL Server async storage backend

### DIFF
--- a/MiniProfiler.sln
+++ b/MiniProfiler.sln
@@ -63,6 +63,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniProfiler.Benchmarks", "benchmarks\MiniProfiler.Benchmarks\MiniProfiler.Benchmarks.csproj", "{9C653E9B-71DA-49D3-83BE-ED78873DE247}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniProfiler.Providers.MySql", "src\MiniProfiler.Providers.MySql\MiniProfiler.Providers.MySql.csproj", "{36ED231C-19C9-4CA3-A085-4066A9B571CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -141,6 +143,10 @@ Global
 		{9C653E9B-71DA-49D3-83BE-ED78873DE247}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C653E9B-71DA-49D3-83BE-ED78873DE247}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C653E9B-71DA-49D3-83BE-ED78873DE247}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36ED231C-19C9-4CA3-A085-4066A9B571CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36ED231C-19C9-4CA3-A085-4066A9B571CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36ED231C-19C9-4CA3-A085-4066A9B571CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36ED231C-19C9-4CA3-A085-4066A9B571CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,6 +170,7 @@ Global
 		{56F62841-5B51-4CA5-9637-96F547DBCAF2} = {6A510DBF-E85F-4D2C-B8F7-006DA31B3418}
 		{E2379D6A-5683-4D68-94A4-E0BED3E55949} = {33644D67-D9BB-4989-9B7A-98D51967059B}
 		{9C653E9B-71DA-49D3-83BE-ED78873DE247} = {16ED1A45-B80E-42A4-BA45-B075668FEDEB}
+		{36ED231C-19C9-4CA3-A085-4066A9B571CD} = {6A510DBF-E85F-4D2C-B8F7-006DA31B3418}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		LessCompiler = 6a2b5b70-1c32-482f-b5c6-0597e2d4e376

--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,7 @@ $projectsToBuild =
     'MiniProfiler.Mvc5',
     'MiniProfiler.AspNetCore',
     'MiniProfiler.AspNetCore.Mvc',
+    'MiniProfiler.Providers.MySql',
     'MiniProfiler.Providers.Redis',
     'MiniProfiler.Providers.SqlServer',
     'MiniProfiler.Providers.SqlServerCe'

--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>MiniProfiler.Providers.MySql</AssemblyName>
+    <Title>MiniProfiler.Providers.MySql</Title>
+    <Description>MiniProfiler: Profiler storage for MySQL</Description>
+    <Authors>Nick Craver, Bradley Grainger</Authors>
+    <PackageTags>SQL;MySQL;$(PackageBaseTags)</PackageTags>
+    <TargetFrameworks>net451;netstandard1.5</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
+    <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
+    <PackageReference Include="MySqlConnector" Version="0.20.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+</Project>

--- a/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
+++ b/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
@@ -1,0 +1,428 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using Dapper;
+using MySql.Data.MySqlClient;
+using StackExchange.Profiling.Helpers;
+using System.Threading.Tasks;
+
+namespace StackExchange.Profiling.Storage
+{
+    /// <summary>
+    /// Understands how to store a <see cref="MiniProfiler"/> to a MySQL database.
+    /// </summary>
+    public sealed class MySqlStorage : DatabaseStorageBase
+    {
+        /// <summary>
+        /// Load the SQL statements (using Dapper Multiple Results)
+        /// </summary>
+        private readonly string SqlStatements = @"
+SELECT * FROM MiniProfilers WHERE Id = @id;
+SELECT * FROM MiniProfilerTimings WHERE MiniProfilerId = @id ORDER BY StartMilliseconds;
+SELECT * FROM MiniProfilerClientTimings WHERE MiniProfilerId = @id ORDER BY Start;";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MySqlStorage"/> class with the specified connection string.
+        /// </summary>
+        /// <param name="connectionString">The connection string to use.</param>
+        public MySqlStorage(string connectionString)
+            : base(connectionString)
+        {
+        }
+
+        private const string _saveSql =
+@"INSERT IGNORE INTO MiniProfilers
+            (Id,  RootTimingId,  Name,  Started,  DurationMilliseconds, User, HasUserViewed,  MachineName,  CustomLinksJson,  ClientTimingsRedirectCount)
+VALUES(@Id, @RootTimingId, @Name, @Started, @DurationMilliseconds, @User, @HasUserViewed, @MachineName, @CustomLinksJson, @ClientTimingsRedirectCount)";
+
+        private const string _saveTimingsSql = @"
+INSERT IGNORE INTO MiniProfilerTimings
+            (Id,  MiniProfilerId,  ParentTimingId,  Name,  DurationMilliseconds,  StartMilliseconds,  IsRoot,  Depth,  CustomTimingsJson)
+VALUES(@Id, @MiniProfilerId, @ParentTimingId, @Name, @DurationMilliseconds, @StartMilliseconds, @IsRoot, @Depth, @CustomTimingsJson)";
+
+        private const string _saveClientTimingsSql = @"
+INSERT IGNORE INTO MiniProfilerClientTimings
+            (Id,  MiniProfilerId,  Name,  Start,  Duration)
+VALUES(@Id, @MiniProfilerId, @Name, @Start, @Duration)";
+
+        /// <summary>
+        /// Stores to <c>dbo.MiniProfilers</c> under its <see cref="MiniProfiler.Id"/>;
+        /// </summary>
+        /// <param name="profiler">The <see cref="MiniProfiler"/> to save.</param>
+        public override void Save(MiniProfiler profiler)
+        {
+            using (var conn = GetConnection())
+            {
+                conn.Execute(_saveSql, new
+                {
+                    profiler.Id,
+                    profiler.Started,
+                    Name = profiler.Name.Truncate(200),
+                    User = profiler.User.Truncate(100),
+                    RootTimingId = profiler.Root?.Id,
+                    profiler.DurationMilliseconds,
+                    profiler.HasUserViewed,
+                    MachineName = profiler.MachineName.Truncate(100),
+                    profiler.CustomLinksJson,
+                    ClientTimingsRedirectCount = profiler.ClientTimings?.RedirectCount
+                });
+
+                var timings = new List<Timing>();
+                if (profiler.Root != null)
+                {
+                    profiler.Root.MiniProfilerId = profiler.Id;
+                    FlattenTimings(profiler.Root, timings);
+                }
+
+                conn.Execute(_saveTimingsSql, timings.Select(timing => new
+                {
+                    timing.Id,
+                    timing.MiniProfilerId,
+                    timing.ParentTimingId,
+                    Name = timing.Name.Truncate(200),
+                    timing.DurationMilliseconds,
+                    timing.StartMilliseconds,
+                    timing.IsRoot,
+                    timing.Depth,
+                    timing.CustomTimingsJson
+                }));
+
+                if (profiler.ClientTimings?.Timings?.Any() ?? false)
+                {
+                    // set the profilerId (isn't needed unless we are storing it)
+                    foreach (var timing in profiler.ClientTimings.Timings)
+                    {
+                        timing.MiniProfilerId = profiler.Id;
+                        timing.Id = Guid.NewGuid();
+                    }
+
+                    conn.Execute(_saveClientTimingsSql, profiler.ClientTimings.Timings.Select(timing => new
+                    {
+                        timing.Id,
+                        timing.MiniProfilerId,
+                        Name = timing.Name.Truncate(200),
+                        timing.Start,
+                        timing.Duration
+                    }));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously stores to <c>dbo.MiniProfilers</c> under its <see cref="MiniProfiler.Id"/>.
+        /// </summary>
+        /// <param name="profiler">The <see cref="MiniProfiler"/> to save.</param>
+        public override async Task SaveAsync(MiniProfiler profiler)
+        {
+            using (var conn = GetConnection())
+            {
+                await conn.ExecuteAsync(_saveSql, new
+                {
+                    profiler.Id,
+                    profiler.Started,
+                    Name = profiler.Name.Truncate(200),
+                    User = profiler.User.Truncate(100),
+                    RootTimingId = profiler.Root?.Id,
+                    profiler.DurationMilliseconds,
+                    profiler.HasUserViewed,
+                    MachineName = profiler.MachineName.Truncate(100),
+                    profiler.CustomLinksJson,
+                    ClientTimingsRedirectCount = profiler.ClientTimings?.RedirectCount
+                }).ConfigureAwait(false);
+
+                var timings = new List<Timing>();
+                if (profiler.Root != null)
+                {
+                    profiler.Root.MiniProfilerId = profiler.Id;
+                    FlattenTimings(profiler.Root, timings);
+                }
+
+                await conn.ExecuteAsync(_saveTimingsSql, timings.Select(timing => new
+                {
+                    timing.Id,
+                    timing.MiniProfilerId,
+                    timing.ParentTimingId,
+                    Name = timing.Name.Truncate(200),
+                    timing.DurationMilliseconds,
+                    timing.StartMilliseconds,
+                    timing.IsRoot,
+                    timing.Depth,
+                    timing.CustomTimingsJson
+                })).ConfigureAwait(false);
+
+                if (profiler.ClientTimings?.Timings?.Any() ?? false)
+                {
+                    // set the profilerId (isn't needed unless we are storing it)
+                    foreach (var timing in profiler.ClientTimings.Timings)
+                    {
+                        timing.MiniProfilerId = profiler.Id;
+                        timing.Id = Guid.NewGuid();
+                    }
+                    await conn.ExecuteAsync(_saveClientTimingsSql, profiler.ClientTimings.Timings.Select(timing => new
+                    {
+                        timing.Id,
+                        timing.MiniProfilerId,
+                        Name = timing.Name.Truncate(200),
+                        timing.Start,
+                        timing.Duration
+                    })).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads the <c>MiniProfiler</c> identified by 'id' from the database.
+        /// </summary>
+        /// <param name="id">The profiler ID to load.</param>
+        /// <returns>The loaded <see cref="MiniProfiler"/>.</returns>
+        public override MiniProfiler Load(Guid id)
+        {
+            MiniProfiler result;
+            using (var conn = GetConnection())
+            {
+                using (var multi = conn.QueryMultiple(SqlStatements, new { id }))
+                {
+                    result = multi.ReadSingleOrDefault<MiniProfiler>();
+                    var timings = multi.Read<Timing>().AsList();
+                    var clientTimings = multi.Read<ClientTiming>().AsList();
+
+                    ConnectTimings(result, timings, clientTimings);
+                }
+            }
+
+            if (result != null)
+            {
+                // HACK: stored dates are utc, but are pulled out as unspecified
+                result.Started = new DateTime(result.Started.Ticks, DateTimeKind.Utc);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Loads the <c>MiniProfiler</c> identified by 'id' from the database.
+        /// </summary>
+        /// <param name="id">The profiler ID to load.</param>
+        /// <returns>The loaded <see cref="MiniProfiler"/>.</returns>
+        public override async Task<MiniProfiler> LoadAsync(Guid id)
+        {
+            MiniProfiler result;
+            using (var conn = GetConnection())
+            {
+                using (var multi = await conn.QueryMultipleAsync(SqlStatements, new { id }).ConfigureAwait(false))
+                {
+                    result = await multi.ReadSingleOrDefaultAsync<MiniProfiler>().ConfigureAwait(false);
+                    var timings = (await multi.ReadAsync<Timing>().ConfigureAwait(false)).AsList();
+                    var clientTimings = (await multi.ReadAsync<ClientTiming>().ConfigureAwait(false)).AsList();
+
+                    ConnectTimings(result, timings, clientTimings);
+                }
+            }
+
+            if (result != null)
+            {
+                // HACK: stored dates are utc, but are pulled out as local time
+                result.Started = new DateTime(result.Started.Ticks, DateTimeKind.Utc);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Sets a particular profiler session so it is considered "un-viewed"  
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as unviewed for.</param>
+        /// <param name="id">The profiler ID to set unviewed.</param>
+        public override void SetUnviewed(string user, Guid id) => ToggleViewed(user, id, false);
+
+        /// <summary>
+        /// Asynchronously sets a particular profiler session so it is considered "un-viewed"  
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as unviewed for.</param>
+        /// <param name="id">The profiler ID to set unviewed.</param>
+        public override Task SetUnviewedAsync(string user, Guid id) => ToggleViewedAsync(user, id, false);
+
+        /// <summary>
+        /// Sets a particular profiler session to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="id">The profiler ID to set viewed.</param>
+        public override void SetViewed(string user, Guid id) => ToggleViewed(user, id, true);
+
+        /// <summary>
+        /// Asynchronously sets a particular profiler session to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="id">The profiler ID to set viewed.</param>
+        public override Task SetViewedAsync(string user, Guid id) => ToggleViewedAsync(user, id, true);
+
+        private const string _toggleViewedSql = @"
+UPDATE MiniProfilers 
+   SET HasUserViewed = @hasUserViewed 
+ WHERE Id = @id 
+   AND User = @user";
+
+        private void ToggleViewed(string user, Guid id, bool hasUserViewed)
+        {
+            using (var conn = GetConnection())
+            {
+                conn.Execute(_toggleViewedSql, new { id, user, hasUserViewed });
+            }
+        }
+
+        private async Task ToggleViewedAsync(string user, Guid id, bool hasUserViewed)
+        {
+            using (var conn = GetConnection())
+            {
+                await conn.ExecuteAsync(_toggleViewedSql, new { id, user, hasUserViewed }).ConfigureAwait(false);
+            }
+        }
+
+        private const string _getUnviewedIdsSql = @"
+  SELECT Id
+    FROM MiniProfilers
+   WHERE User = @user
+     AND HasUserViewed = 0
+ORDER BY Started";
+
+        /// <summary>
+        /// Returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">User identified by the current <c>MiniProfiler.Settings.UserProvider</c></param>
+        /// <returns>The list of keys for the supplied user</returns>
+        public override List<Guid> GetUnviewedIds(string user)
+        {
+            using (var conn = GetConnection())
+            {
+                return conn.Query<Guid>(_getUnviewedIdsSql, new { user }).AsList();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">User identified by the current <c>MiniProfiler.Settings.UserProvider</c></param>
+        /// <returns>The list of keys for the supplied user</returns>
+        public override async Task<List<Guid>> GetUnviewedIdsAsync(string user)
+        {
+            using (var conn = GetConnection())
+            {
+                return (await conn.QueryAsync<Guid>(_getUnviewedIdsSql, new { user }).ConfigureAwait(false)).AsList();
+            }
+        }
+
+        /// <summary>
+        /// List the MiniProfiler Ids for the given search criteria.
+        /// </summary>
+        /// <param name="maxResults">The max number of results</param>
+        /// <param name="start">Search window start</param>
+        /// <param name="finish">Search window end</param>
+        /// <param name="orderBy">Result order</param>
+        /// <returns>The list of GUID keys</returns>
+        public override IEnumerable<Guid> List(int maxResults, DateTime? start = null, DateTime? finish = null, ListResultsOrder orderBy = ListResultsOrder.Descending)
+        {
+            using (var conn = GetConnection())
+            {
+                var query = BuildListQuery(start, finish, orderBy);
+                return conn.Query<Guid>(query, new { maxResults, start, finish }).AsList();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously returns the MiniProfiler Ids for the given search criteria.
+        /// </summary>
+        /// <param name="maxResults">The max number of results</param>
+        /// <param name="start">Search window start</param>
+        /// <param name="finish">Search window end</param>
+        /// <param name="orderBy">Result order</param>
+        /// <returns>The list of GUID keys</returns>
+        public override async Task<IEnumerable<Guid>> ListAsync(int maxResults, DateTime? start = null, DateTime? finish = null, ListResultsOrder orderBy = ListResultsOrder.Descending)
+        {
+            using (var conn = GetConnection())
+            {
+                var query = BuildListQuery(start, finish, orderBy);
+                return await conn.QueryAsync<Guid>(query, new { maxResults, start, finish }).ConfigureAwait(false);
+            }
+        }
+
+        private static string BuildListQuery(DateTime? start = null, DateTime? finish = null, ListResultsOrder orderBy = ListResultsOrder.Descending)
+        {
+            var sb = new StringBuilder(@"
+SELECT Id
+  FROM MiniProfilers
+");
+            if (finish != null)
+            {
+                sb.AppendLine("WHERE Started < @finish");
+            }
+            if (start != null)
+            {
+                sb.AppendLine(finish != null
+                    ? "  AND Started > @start"
+                    : "WHERE Started > @start");
+            }
+            sb.Append("ORDER BY ").Append(orderBy == ListResultsOrder.Descending ? "Started DESC" : "Started ASC");
+            sb.Append(" LIMIT @maxResults");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns a connection to MySQL Server.
+        /// </summary>
+        protected override DbConnection GetConnection() => new MySqlConnection(ConnectionString);
+
+        /// <summary>
+        /// Creates needed tables. Run this once on your database.
+        /// </summary>
+        /// <remarks>
+        /// Works in SQL server and <c>sqlite</c> (with documented removals).
+        /// </remarks>
+        public const string TableCreationScript = @"
+                create table MiniProfilers
+                  (
+                     RowId                                integer not null auto_increment primary key,
+                     Id                                   char(36) not null collate ascii_general_ci,
+                     RootTimingId                         char(36) null collate ascii_general_ci,
+                     Name                                 varchar(200) null,
+                     Started                              datetime not null,
+                     DurationMilliseconds                 decimal(7, 1) not null,
+                     User                                 varchar(100) null,
+                     HasUserViewed                        bool not null,
+                     MachineName                          varchar(100) null,
+                     CustomLinksJson                      longtext,
+                     ClientTimingsRedirectCount           int null,
+                     unique index IX_MiniProfilers_Id (Id), -- displaying results selects everything based on the main MiniProfilers.Id column
+                     index IX_MiniProfilers_User_HasUserViewed (User, HasUserViewed) -- speeds up a query that is called on every .Stop()
+                  ) engine=InnoDB collate utf8mb4_bin;
+
+                create table MiniProfilerTimings
+                  (
+                     RowId                               integer not null auto_increment primary key,
+                     Id                                  char(36) not null collate ascii_general_ci,
+                     MiniProfilerId                      char(36) not null collate ascii_general_ci,
+                     ParentTimingId                      char(36) null collate ascii_general_ci,
+                     Name                                varchar(200) not null,
+                     DurationMilliseconds                decimal(9, 3) not null,
+                     StartMilliseconds                   decimal(9, 3) not null,
+                     IsRoot                              bool not null,
+                     Depth                               smallint not null,
+                     CustomTimingsJson                   longtext null,
+                     unique index IX_MiniProfilerTimings_Id (Id),
+                     index IX_MiniProfilerTimings_MiniProfilerId (MiniProfilerId)
+                  ) engine=InnoDB collate utf8mb4_bin;
+
+                 create table MiniProfilerClientTimings
+                  (
+                     RowId                               integer not null auto_increment primary key,
+                     Id                                  char(36) not null collate ascii_general_ci,
+                     MiniProfilerId                      char(36) not null collate ascii_general_ci,
+                     Name                                varchar(200) not null,
+                     Start                               decimal(9, 3) not null,
+                     Duration                            decimal(9, 3) not null,
+                     unique index IX_MiniProfilerClientTimings_Id (Id),
+                     index IX_MiniProfilerClientTimings_MiniProfilerId (MiniProfilerId)
+                  ) engine=InnoDB collate utf8mb4_bin;
+                ";
+    }
+}


### PR DESCRIPTION
This adds an `IAsyncStorage` implementation that stores data in MySQL Server. It uses my [MySqlConnector library](https://github.com/mysql-net/MySqlConnector) so DB operations are truly async. It builds for `net451` and `netstandard1.5`.

Q: Do you want this code as part of the core MiniProfiler repository, or would you prefer it to be in its own repo and maintained separately?

90% of the code was ["derived from"](http://typicalprogrammer.com/introduction-to-abject-oriented-programming) `SqlServerStorage.cs`; if you are OK with the code being in this repo, I could refactor out that duplicated code into a new `StandardDatabaseStorageBase` abstract base class that contains the core DB logic and gets the SQL statements from its derived classes. (That could be done in this PR or a follow-up one.)