### PR TITLE
Entity Framework 6 Profiling Enhancements

### DIFF
--- a/src/MiniProfiler.EF6/EFProfiledDbConnectionFactory.cs
+++ b/src/MiniProfiler.EF6/EFProfiledDbConnectionFactory.cs
@@ -5,7 +5,7 @@ using StackExchange.Profiling.Data;
 namespace StackExchange.Profiling.EntityFramework6
 {
     /// <summary>
-    /// Wrapper for an IDbConnectionFactory
+    /// Wrapper for an <see cref="IDbConnectionFactory"/>
     /// </summary>
     public class EFProfiledDbConnectionFactory : IDbConnectionFactory
     {
@@ -14,7 +14,7 @@ namespace StackExchange.Profiling.EntityFramework6
         /// <summary>
         /// Initialises a new instance of the <see cref="EFProfiledDbConnectionFactory"/> class.
         /// </summary>
-        /// <param name="inner">The IDbConnectionFactory to wrap.</param>
+        /// <param name="inner">The <see cref="IDbConnectionFactory"/> to wrap.</param>
         public EFProfiledDbConnectionFactory(IDbConnectionFactory inner)
         {
             _inner = inner;
@@ -24,7 +24,7 @@ namespace StackExchange.Profiling.EntityFramework6
         /// Creates a connection based on the given database name or connection string.
         /// </summary>
         /// <param name="nameOrConnectionString">The database name or connection string.</param>
-        /// <returns>An initialized DbConnection.</returns>
+        /// <returns>An initialized <see cref="DbConnection"/>.</returns>
         public DbConnection CreateConnection(string nameOrConnectionString)
         {
             var connection = _inner.CreateConnection(nameOrConnectionString);

--- a/src/MiniProfiler.EF6/EFProfiledDbConnectionFactory.cs
+++ b/src/MiniProfiler.EF6/EFProfiledDbConnectionFactory.cs
@@ -1,0 +1,42 @@
+﻿using System.Data.Common;
+using System.Data.Entity.Infrastructure;
+using StackExchange.Profiling.Data;
+
+namespace StackExchange.Profiling.EntityFramework6
+{
+    /// <summary>
+    /// Wrapper for an IDbConnectionFactory
+    /// </summary>
+    public class EFProfiledDbConnectionFactory : IDbConnectionFactory
+    {
+        private readonly IDbConnectionFactory _inner;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="EFProfiledDbConnectionFactory"/> class.
+        /// </summary>
+        /// <param name="inner">The IDbConnectionFactory to wrap.</param>
+        public EFProfiledDbConnectionFactory(IDbConnectionFactory inner)
+        {
+            _inner = inner;
+        }
+
+        /// <summary>
+        /// Creates a connection based on the given database name or connection string.
+        /// </summary>
+        /// <param name="nameOrConnectionString">The database name or connection string.</param>
+        /// <returns>An initialized DbConnection.</returns>
+        public DbConnection CreateConnection(string nameOrConnectionString)
+        {
+            var connection = _inner.CreateConnection(nameOrConnectionString);
+            if (connection is ProfiledDbConnection)
+            {
+                return connection;
+            }
+
+            var profiler = MiniProfiler.Current;
+            return profiler != null
+                ? new ProfiledDbConnection(connection, profiler)
+                : connection;
+        }
+    }
+}

--- a/src/MiniProfiler.EF6/EFProfiledDbProviderFactoryResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledDbProviderFactoryResolver.cs
@@ -5,8 +5,8 @@ using StackExchange.Profiling.Data;
 namespace StackExchange.Profiling.EntityFramework6
 {
     /// <summary>
-    /// Wrapper for a service for obtaining the correct System.Data.Common.DbProviderFactory from
-    //  a given System.Data.Common.DbConnection.
+    /// Wrapper for a service for obtaining the correct <see cref="DbProviderFactory"/> from
+    /// a given <see cref="DbConnection"/>.
     /// </summary>
     public class EFProfiledDbProviderFactoryResolver : IDbProviderFactoryResolver
     {
@@ -15,15 +15,15 @@ namespace StackExchange.Profiling.EntityFramework6
         /// <summary>
         /// Initialises a new instance of the <see cref="EFProfiledDbProviderFactoryResolver"/> class.
         /// </summary>
-        /// <param name="inner">The IDbProviderFactoryResolver to wrap.</param>
+        /// <param name="inner">The <see cref="IDbProviderFactoryResolver"/> to wrap.</param>
         public EFProfiledDbProviderFactoryResolver(IDbProviderFactoryResolver inner)
         {
             _inner = inner;
         }
 
         /// <summary>
-        /// Returns the System.Data.Common.DbProviderFactory for the given connection,
-        /// unwrapping the ProfiledDbConnection as necessary
+        /// Returns the <see cref="DbProviderFactory"/> for the given connection,
+        /// unwrapping the <see cref="ProfiledDbConnection"/> as necessary
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <returns>The provider factory for the connection.</returns>

--- a/src/MiniProfiler.EF6/EFProfiledDbProviderFactoryResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledDbProviderFactoryResolver.cs
@@ -1,0 +1,35 @@
+﻿using System.Data.Common;
+using System.Data.Entity.Infrastructure;
+using StackExchange.Profiling.Data;
+
+namespace StackExchange.Profiling.EntityFramework6
+{
+    /// <summary>
+    /// Wrapper for a service for obtaining the correct System.Data.Common.DbProviderFactory from
+    //  a given System.Data.Common.DbConnection.
+    /// </summary>
+    public class EFProfiledDbProviderFactoryResolver : IDbProviderFactoryResolver
+    {
+        private readonly IDbProviderFactoryResolver _inner;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="EFProfiledDbProviderFactoryResolver"/> class.
+        /// </summary>
+        /// <param name="inner">The IDbProviderFactoryResolver to wrap.</param>
+        public EFProfiledDbProviderFactoryResolver(IDbProviderFactoryResolver inner)
+        {
+            _inner = inner;
+        }
+
+        /// <summary>
+        /// Returns the System.Data.Common.DbProviderFactory for the given connection,
+        /// unwrapping the ProfiledDbConnection as necessary
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <returns>The provider factory for the connection.</returns>
+        public DbProviderFactory ResolveProviderFactory(DbConnection connection)
+        {
+            return _inner.ResolveProviderFactory(connection is ProfiledDbConnection profiled ? profiled.InnerConnection : connection);
+        }
+    }
+}

--- a/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
@@ -11,7 +11,7 @@ using StackExchange.Profiling.Data;
 namespace StackExchange.Profiling.EntityFramework6
 {
     /// <summary>
-    /// Replacement for the DefaultInvariantNameResolver which can correctly resolve an IProviderInvariantName given a ProfiledDbProviderFactory.
+    /// Replacement for the DefaultInvariantNameResolver which can correctly resolve an <see cref="IProviderInvariantName"/> given a <see cref="ProfiledDbProviderFactory"/>.
     /// </summary>
     internal class EFProfiledInvariantNameResolver : IDbDependencyResolver
     {

--- a/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
@@ -41,11 +41,11 @@ namespace StackExchange.Profiling.EntityFramework6
         {
             // Avert your eyes. EF6 implenents a handy helper method to get the Invariant Name given a DbProviderFactory instance,
             // but of course it is marked internal. Rather than rewrite all of that code, we'll just call into it via reflection and cache the result.
-            var extensionsType = Type.GetType("System.Data.Entity.Utilities.DbProviderFactoryExtensions, EntityFramework");
-            var GetProviderInvariantNameMethod = extensionsType.GetMethod("GetProviderInvariantName", BindingFlags.Static | BindingFlags.Public);
             try
             {
-                var providerInvariantName = (string)GetProviderInvariantNameMethod.Invoke(null, new[] { factory });
+                var extensionsType = Type.GetType("System.Data.Entity.Utilities.DbProviderFactoryExtensions, EntityFramework");
+                var getProviderInvariantNameMethod = extensionsType.GetMethod("GetProviderInvariantName", BindingFlags.Static | BindingFlags.Public);
+                var providerInvariantName = (string)getProviderInvariantNameMethod.Invoke(null, new[] { factory });
                 return new ProviderInvariantName(providerInvariantName);
             }
             catch (TargetInvocationException ex)

--- a/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
@@ -15,7 +15,7 @@ namespace StackExchange.Profiling.EntityFramework6
     /// </summary>
     internal class EFProfiledInvariantNameResolver : IDbDependencyResolver
     {
-        private static ConcurrentDictionary<DbProviderFactory, IProviderInvariantName> _providerInvariantNameCache = new ConcurrentDictionary<DbProviderFactory, IProviderInvariantName>();
+        private ConcurrentDictionary<DbProviderFactory, IProviderInvariantName> _providerInvariantNameCache = new ConcurrentDictionary<DbProviderFactory, IProviderInvariantName>();
 
         public object GetService(Type type, object key)
         {

--- a/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
+++ b/src/MiniProfiler.EF6/EFProfiledInvariantNameResolver.cs
@@ -39,7 +39,7 @@ namespace StackExchange.Profiling.EntityFramework6
 
         private static IProviderInvariantName GetProviderInvariantNameViaReflection(DbProviderFactory factory)
         {
-            // Avert your eyes. EF6 implenents a handy helper method to get the Invariant Name given a DbProviderFactory instance,
+            // Avert your eyes. EF6 implements a handy helper method to get the Invariant Name given a DbProviderFactory instance,
             // but of course it is marked internal. Rather than rewrite all of that code, we'll just call into it via reflection and cache the result.
             try
             {

--- a/src/MiniProfiler.EF6/MiniProfilerEF6.cs
+++ b/src/MiniProfiler.EF6/MiniProfilerEF6.cs
@@ -45,11 +45,11 @@ namespace StackExchange.Profiling.EntityFramework6
             }
         }
 
-        private static readonly ConcurrentDictionary<object, DbProviderServices> _wrappedDbProviderServices = new ConcurrentDictionary<object, DbProviderServices>();
+        private static readonly ConcurrentDictionary<object, DbProviderServices> _wrappedDbProviderServicesCache = new ConcurrentDictionary<object, DbProviderServices>();
 
         private static DbProviderServices WrapDbProviderServices(DbProviderServices inner, object key)
         {
-            return _wrappedDbProviderServices.GetOrAdd(key, _ => new EFProfiledDbProviderServices(inner));
+            return _wrappedDbProviderServicesCache.GetOrAdd(key, _ => new EFProfiledDbProviderServices(inner));
         }
 
         private static readonly ConcurrentDictionary<object, DbProviderFactory> _wrappedDbProviderFactoryCache = new ConcurrentDictionary<object, DbProviderFactory>();

--- a/src/MiniProfiler.EF6/MiniProfilerEF6.cs
+++ b/src/MiniProfiler.EF6/MiniProfilerEF6.cs
@@ -13,8 +13,6 @@ namespace StackExchange.Profiling.EntityFramework6
     /// </summary>
     public static class MiniProfilerEF6
     {
-        private static readonly ConcurrentDictionary<object, object>  _resolvedDependenciesCache = new ConcurrentDictionary<object, object>();
-
         /// <summary>
         /// Registers the WrapProviderService method with the Entity Framework 6 DbConfiguration as a replacement service for DbProviderServices.
         /// </summary>
@@ -47,28 +45,32 @@ namespace StackExchange.Profiling.EntityFramework6
             }
         }
 
+        private static readonly ConcurrentDictionary<object, DbProviderServices> _wrappedDbProviderServices = new ConcurrentDictionary<object, DbProviderServices>();
+
         private static DbProviderServices WrapDbProviderServices(DbProviderServices inner, object key)
         {
-            var cacheKey = new { type = typeof(DbProviderServices), key }; // TODO: consider using ValueTuple or implementing a similar polyfill
-            return (DbProviderServices)_resolvedDependenciesCache.GetOrAdd(cacheKey, _ => new EFProfiledDbProviderServices(inner));
+            return _wrappedDbProviderServices.GetOrAdd(key, _ => new EFProfiledDbProviderServices(inner));
         }
+
+        private static readonly ConcurrentDictionary<object, DbProviderFactory> _wrappedDbProviderFactoryCache = new ConcurrentDictionary<object, DbProviderFactory>();
 
         private static DbProviderFactory WrapDbProviderFactory(DbProviderFactory inner, object key)
         {
-            var cacheKey = new { type = typeof(DbProviderFactory), key };
-            return (DbProviderFactory)_resolvedDependenciesCache.GetOrAdd(cacheKey, _ => new ProfiledDbProviderFactory(inner));
+            return _wrappedDbProviderFactoryCache.GetOrAdd(key, _ => new ProfiledDbProviderFactory(inner));
         }
+
+        private static readonly ConcurrentDictionary<object, IDbProviderFactoryResolver> _wrappedIDbProviderFactoryResolverCache = new ConcurrentDictionary<object, IDbProviderFactoryResolver>();
 
         private static IDbProviderFactoryResolver WrapIDbProviderFactoryResolver(IDbProviderFactoryResolver inner, object key)
         {
-            var cacheKey = new { type = typeof(IDbProviderFactoryResolver), key };
-            return (IDbProviderFactoryResolver)_resolvedDependenciesCache.GetOrAdd(cacheKey, _ => new EFProfiledDbProviderFactoryResolver(inner));
+            return _wrappedIDbProviderFactoryResolverCache.GetOrAdd(key, _ => new EFProfiledDbProviderFactoryResolver(inner));
         }
+
+        private static readonly ConcurrentDictionary<object, IDbConnectionFactory> _wrappedIDbConnectionFactoryCache = new ConcurrentDictionary<object, IDbConnectionFactory>();
 
         private static IDbConnectionFactory WrapIDbConnectionFactory(IDbConnectionFactory inner, object key)
         {
-            var cacheKey = new { type = typeof(IDbConnectionFactory), key };
-            return (IDbConnectionFactory)_resolvedDependenciesCache.GetOrAdd(cacheKey, _ => new EFProfiledDbConnectionFactory(inner));
+            return _wrappedIDbConnectionFactoryCache.GetOrAdd(key, _ => new EFProfiledDbConnectionFactory(inner));
         }
     }
 }

--- a/src/MiniProfiler.Shared/Data/ProfiledDbProviderFactory.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbProviderFactory.cs
@@ -15,6 +15,8 @@ namespace StackExchange.Profiling.Data
         private DbProviderFactory _tail;
         private readonly bool _alwaysWrap;
 
+        public DbProviderFactory InnerDbProviderFactory => _tail;
+
         /// <summary>
         /// Every provider factory must have an Instance public field
         /// </summary>


### PR DESCRIPTION
This pull request provides a number of enhancements to profiling EF6 based on our usage.

1. Cache the `EFProfiledDbProviderServices` instance.

Internally DbProviderServices is registered as a singleton. However when the service is "replaced" via `ReplaceService<>()`, the interception func is executed *every time* the service is resolved. We can cache the `EFProfiledDbProviderServices` instance (and anything else we want to replace) based on the type and key.

This should hopefully help keep the profiling overhead low.

2. The current implementation, which replaces `EFProfiledDbProviderServices`, only supports cached commands that cloned when needed by EF. The `Clone()` method creates a new `ProfiledDbCommand` with the current `MiniProfiler`. However for some queries, EF6 will use `DbConnection.CreateCommand()` - and since we do not setup a `ProfiledDbConnection`, these queries *are not profiled*.

To fix these, we can wrap both `DbProviderFactory` and EF's `IDbConnectionFactory` - EF will use one or the other based on the type of connection string and how the DbContext is constructed.

This should also resolve #130.

Unfortunately to support this additional wrapping, we also need to implement our own `IDbProviderFactoryResolver` and a resolver for `IProviderInvariantName`. The implementation of `EFProfiledInvariantNameResolver ` in particular is **not pretty**. But it works.

Based on our initial testing, these these work without issue. Hopefully it works as well for others.

P.S. EF6 is annoying as hell. But I'm working hard to make this thing work.