### PR TITLE
Ignore Duplicate based on ExecuteType (Fixes #194)

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
@@ -107,7 +107,7 @@ namespace StackExchange.Profiling.Data
                 return;
             }
 
-            using (miniProfiler.CustomTiming("sql", "Connection Open()", "Open"))
+            using (miniProfiler.CustomTiming("sql", "Connection Open()", nameof(Open)))
             {
                 _connection.Open();
             }
@@ -126,7 +126,7 @@ namespace StackExchange.Profiling.Data
                 return;
             }
 
-            using (miniProfiler.CustomTiming("sql", "Connection OpenAsync()", "OpenAsync"))
+            using (miniProfiler.CustomTiming("sql", "Connection OpenAsync()", nameof(OpenAsync)))
             {
                 await _connection.OpenAsync(cancellationToken);
             }

--- a/src/MiniProfiler.Shared/Internal/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.Shared/Internal/MiniProfilerExtensions.cs
@@ -98,6 +98,21 @@ namespace StackExchange.Profiling.Internal
             sb.Append("\" data-trivial-milliseconds=\"");
             sb.Append(MiniProfiler.Settings.TrivialDurationThresholdMilliseconds.ToString(CultureInfo.InvariantCulture));
 
+            if (MiniProfiler.Settings.IgnoredDuplicateExecuteTypes.Count > 0)
+            {
+                sb.Append("\" data-ignored-duplicate-execute-types=\"");
+                var i = 0;
+                foreach (var executeType in MiniProfiler.Settings.IgnoredDuplicateExecuteTypes)
+                {
+                    if (i > 0)
+                    {
+                        sb.Append(',');
+                    }
+                    sb.Append(executeType);
+                    i++;
+                }
+            }
+
             sb.Append("\"></script>");
 
             return sb.ToStringRecycle();

--- a/src/MiniProfiler.Shared/MiniProfiler.Settings.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.Settings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using StackExchange.Profiling.Data;
 using StackExchange.Profiling.Helpers;
 using StackExchange.Profiling.SqlFormatters;
 using StackExchange.Profiling.Storage;
@@ -146,6 +147,15 @@ namespace StackExchange.Profiling
             /// For a per-page override you can use .RenderIncludes(showControls: true/false)
             /// </summary>
             public static bool ShowControls { get; set; } = false;
+
+            /// <summary>
+            /// Custom timing ExecuteTypes to ignore as duplicates in the UI.
+            /// </summary>
+            public static HashSet<string> IgnoredDuplicateExecuteTypes { get; } = new HashSet<string>()
+            {
+                nameof(ProfiledDbConnection.Open),
+                nameof(ProfiledDbConnection.OpenAsync),
+            };
 
             /// <summary>
             /// By default, <see cref="CustomTiming"/>s created by this assmebly will grab a stack trace to help 

--- a/src/MiniProfiler.Shared/ui/includes.js
+++ b/src/MiniProfiler.Shared/ui/includes.js
@@ -220,7 +220,7 @@ var MiniProfiler = (function () {
                         customTiming.IsDuplicate = true;
                         timing.HasDuplicateCustomTimings[customType] = true;
                         json.HasDuplicateCustomTimings = true;
-                    } else {
+                    } else if (!ignoreDuplicateCustomTiming(customTiming)) {
                         duplicates[customTiming.CommandString] = true;
                     }
                 }
@@ -237,6 +237,10 @@ var MiniProfiler = (function () {
         } else {
             timing.CustomTimings = {};
         }
+    };
+
+    var ignoreDuplicateCustomTiming = function (customTiming) {
+        return customTiming.ExecuteType && $.inArray(customTiming.ExecuteType, options.ignoredDuplicateExecuteTypes) > -1;
     };
 
     var renderTemplate = function (json) {
@@ -754,7 +758,8 @@ var MiniProfiler = (function () {
                 currentId: data.currentId,
                 authorized: data.authorized,
                 toggleShortcut: data.toggleShortcut,
-                startHidden: data.startHidden
+                startHidden: data.startHidden,
+                ignoredDuplicateExecuteTypes: (data.ignoredDuplicateExecuteTypes || '').split(',')
             };
 
             var doInit = function () {


### PR DESCRIPTION
Introducing a new "CustomTimingExecuteTypesToIgnoreAsDuplicate" setting to
explicitly ignore duplicate custom timings based on its execute type.

By default it will ignore "Open" and "OpenAsync".