### PR TITLE
Added link to results-index page 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}\\samples\\Samples.AspNetCore\\bin\\Debug\\netcoreapp1.0\\Samples.AspNetCore.dll",
+            "program": "${workspaceRoot}/samples/Samples.AspNetCore/bin/Debug/netcoreapp1.0/Samples.AspNetCore.dll",
             "args": [],
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceRoot}/samples/Samples.AspNetCore",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart",
             "launchBrowser": {

--- a/samples/Samples.AspNetCore/Views/Home/Index.LeftPanel.cshtml
+++ b/samples/Samples.AspNetCore/Views/Home/Index.LeftPanel.cshtml
@@ -28,7 +28,7 @@
                     {
                     <li><a asp-controller="Test" asp-action="DisableProfilingUI">Disable profiling UI</a></li>
                     }
-                <li><a href="/mini-profiler-resources/results-index">Show all profiling sessions</a></li>
+                <li><a href="/profiler/results-index">Show all profiling sessions</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
It would be nice to have a link to the **result-index** page in the miniprofiler "widget" so I do not have to remember the link or put it in my own site.

Result looks like this: 
![newminiprofilerwidget](https://user-images.githubusercontent.com/656406/29094252-f6ca4fa2-7c8c-11e7-8042-2dcb0152714e.PNG)

This PR also contains fix for vscode configurion (launch.json) and fixed link in AspNetCore sample project