### PR TITLE
NetCore: Add a new SQLite Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ packages/**/*.*
 docs/_site
 BenchmarkDotNet.Artifacts
 samples/Samples.Mvc5/Properties/launchSettings.json
+samples/Samples.AspNetCore/Profiler.sqlite

--- a/MiniProfiler.sln
+++ b/MiniProfiler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26906.1
+VisualStudioVersion = 15.0.26730.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{CC40098D-04F2-4F43-B5CF-B74F74351761}"
 	ProjectSection(SolutionItems) = preProject
@@ -70,6 +70,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ConsoleCore", "samples\Samples.ConsoleCore\Samples.ConsoleCore.csproj", "{63DADF8D-87D2-4471-B473-8322C6EDE98C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniProfiler.Providers.Sqlite", "src\MiniProfiler.Providers.Sqlite\MiniProfiler.Providers.Sqlite.csproj", "{513C06B7-32FD-4833-8B04-A1A3C375634D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniProfiler.Providers.Sqlite.EF", "src\MiniProfiler.Providers.Sqlite.EF\MiniProfiler.Providers.Sqlite.EF.csproj", "{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -161,6 +163,10 @@ Global
 		{513C06B7-32FD-4833-8B04-A1A3C375634D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{513C06B7-32FD-4833-8B04-A1A3C375634D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{513C06B7-32FD-4833-8B04-A1A3C375634D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,10 +193,11 @@ Global
 		{36ED231C-19C9-4CA3-A085-4066A9B571CD} = {6A510DBF-E85F-4D2C-B8F7-006DA31B3418}
 		{63DADF8D-87D2-4471-B473-8322C6EDE98C} = {E0DA4035-4D64-4BB8-8EA1-42197DE62519}
 		{513C06B7-32FD-4833-8B04-A1A3C375634D} = {6A510DBF-E85F-4D2C-B8F7-006DA31B3418}
+		{7C20B2E1-2DF4-4C56-A14F-AF2C676CE7DE} = {6A510DBF-E85F-4D2C-B8F7-006DA31B3418}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {9373F37A-A996-4545-A251-1902C8886E3F}
 		LessCompiler = 6a2b5b70-1c32-482f-b5c6-0597e2d4e376
+		SolutionGuid = {9373F37A-A996-4545-A251-1902C8886E3F}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = StackExchange.Profiling.vsmdi

--- a/samples/Samples.AspNetCore/Samples.AspNetCore.csproj
+++ b/samples/Samples.AspNetCore/Samples.AspNetCore.csproj
@@ -5,9 +5,13 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Profiler.sqlite" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <ProjectReference Include="..\..\src\MiniProfiler.AspNetCore.Mvc\MiniProfiler.AspNetCore.Mvc.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.EntityFrameworkCore\MiniProfiler.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\MiniProfiler.Providers.Sqlite.EF\MiniProfiler.Providers.Sqlite.EF.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.SqlServer\MiniProfiler.Providers.SqlServer.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Samples.AspNetCore/Startup.cs
+++ b/samples/Samples.AspNetCore/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Samples.AspNetCore.Models;
+using StackExchange.Profiling.Storage;
 
 namespace Samples.AspNetCore
 {
@@ -39,6 +40,8 @@ namespace Samples.AspNetCore
             // Note .AddMiniProfiler() returns a IMiniProfilerBuilder for easy intellisense
             services.AddMiniProfiler(options =>
             {
+                //options.Storage = new SqliteMiniProfilerStorage("Data Source=Profiler.sqlite", true); //Switch to OnDisk SQLite Storage
+                //options.Storage = new SqliteMiniProfilerStorage(Startup.SqliteConnectionString, true); //Or Switch to In memory SQLite Storage
                 // ALL of this is optional. You can simply call .AddMiniProfiler() for all defaults
                 // Defaults: In-Memory for 30 minutes, everything profiled, every user can see
 

--- a/src/MiniProfiler.Providers.Sqlite.EF/MiniProfiler.Providers.Sqlite.EF.csproj
+++ b/src/MiniProfiler.Providers.Sqlite.EF/MiniProfiler.Providers.Sqlite.EF.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilerClientTimings.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilerClientTimings.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace StackExchange.Profiling.Storage
+{
+	public class MiniProfilerClientTimings
+	{ 
+		[Key]
+		public Int64 RowId { get; set; }
+		public Guid Id { get; set; }
+		public Guid MiniProfilerId { get; set; }
+		public string Name { get; set; }
+		public decimal Start { get; set; }
+		public decimal Duration { get; set; }
+	}
+}

--- a/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilerTimings.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilerTimings.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace StackExchange.Profiling.Storage
+{
+    public class MiniProfilerTimings
+    {
+		[Key]
+		public long RowId { get; set; }
+		public Guid Id { get; set; }
+		public Guid MiniProfilerId { get; set; }
+		public Guid ParentTimingId { get; set; }
+		public string Name { get; set; }
+		public decimal? DurationMilliseconds { get; set; }
+		public decimal StartMilliseconds { get; set; }
+		public bool IsRoot { get; set; }
+		public short Depth { get; set; }
+		public string CustomTimingsJson { get; set; }
+	}
+}

--- a/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilers.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/MiniProfilers.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace StackExchange.Profiling.Storage
+{
+	public class MiniProfilers
+	{
+		[Key]
+		public long RowId { get; set; }
+		public Guid Id { get; set; }
+		public Guid? RootTimingId { get; set; }
+		public string Name { get; set; }
+		public DateTime Started { get; set; }
+		public decimal DurationMilliseconds { get; set; }
+		public string User { get; set; }
+		public bool HasUserViewed { get; set; }
+		public string MachineName { get; set; }
+		public string CustomLinksJson { get; set; }
+		public int? ClientTimingsRedirectCount { get; set; }
+	}
+}

--- a/src/MiniProfiler.Providers.Sqlite.EF/ProfileDbContextFactory.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/ProfileDbContextFactory.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace StackExchange.Profiling.Storage
+{
+    public interface IDataContextFactory
+    {
+        ProfilerDbContext Create();
+    }
+
+    public class ProfilerDbContextFactory : IDataContextFactory
+    {
+        private string Connectionstring { get; }
+        public ProfilerDbContextFactory(string connectionString)
+        {
+            Connectionstring = connectionString;
+        }
+        public ProfilerDbContext Create()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<ProfilerDbContext>();
+            optionsBuilder.UseSqlite(Connectionstring);
+
+            return new ProfilerDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/src/MiniProfiler.Providers.Sqlite.EF/ProfilerDBContext.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/ProfilerDBContext.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace StackExchange.Profiling.Storage
+{
+    public class ProfilerDbContext : DbContext
+    {
+        public DbSet<MiniProfilers> MiniProfilers { get; set; }
+        public DbSet<MiniProfilerTimings> MiniProfilerTimings { get; set; }
+        public DbSet<MiniProfilerClientTimings> MiniProfilerClientTimings { get; set; }
+
+        public ProfilerDbContext(DbContextOptions<ProfilerDbContext> options) : base(options)
+        {
+        }
+
+        public bool Init(bool recreate)
+        {
+            if(recreate) Database.EnsureDeleted();
+            return Database.EnsureCreated();
+        }
+    }
+}

--- a/src/MiniProfiler.Providers.Sqlite.EF/SqliteMiniProfilerStorage.cs
+++ b/src/MiniProfiler.Providers.Sqlite.EF/SqliteMiniProfilerStorage.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Profiling.Internal;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace StackExchange.Profiling.Storage
+{
+    // <summary>
+    /// The SQLITE mini profiler storage.
+    /// </summary>
+    public class SqliteMiniProfilerStorage : DatabaseStorageBase
+    {
+        public IDataContextFactory ContextFactory { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteMiniProfilerStorage"/> class.
+        /// </summary>
+        /// <param name="connectionString">The connection string.</param>
+        public SqliteMiniProfilerStorage(string connectionString, bool recreate = false) : base(connectionString)
+        {
+            ContextFactory = new ProfilerDbContextFactory(connectionString);
+
+            using (var dbContext = GetDbContext())
+            {
+                dbContext.Init(recreate);
+            }
+        }
+
+        private ProfilerDbContext GetDbContext()
+        {
+            return ContextFactory.Create();
+        }
+
+        /// The list of results.
+        /// </summary>
+        /// <param name="maxResults">The max results.</param>
+        /// <param name="start">The start</param>
+        /// <param name="finish">The finish</param>
+        /// <param name="orderBy">The order by.</param>
+        /// <returns>The result set</returns>
+        public override IEnumerable<Guid> List(int maxResults, DateTime? start = null, DateTime? finish = null, ListResultsOrder orderBy = ListResultsOrder.Descending)
+        {
+            var task = ListAsync(maxResults, start, finish, orderBy);
+            task.Wait();
+            return task.Result;
+        }
+
+        public async override Task<IEnumerable<Guid>> ListAsync(int maxResults, DateTime? start = null, DateTime? finish = null, ListResultsOrder orderBy = ListResultsOrder.Descending)
+        {
+            using (var DbContext = GetDbContext())
+            {
+                var query = DbContext.MiniProfilers
+                    .Where(w => (finish == null || w.Started < finish.Value) && (start == null || w.Started > start.Value));
+
+                query = orderBy == ListResultsOrder.Ascending ? query.OrderBy(o => o.Started) : query.OrderByDescending(o => o.Started);
+
+                return await query.Take(maxResults).Select(s => s.Id).ToListAsync();
+            }
+        }
+
+        /// <summary>
+        /// Stores to <c>dbo.MiniProfilers</c> under its <see cref="MiniProfiler.Id"/>;
+        /// </summary>
+        /// <param name="profiler">The <see cref="MiniProfiler"/> to save.</param>
+        public override void Save(MiniProfiler profiler)
+        {
+            SaveAsync(profiler).Wait();
+        }
+
+        /// <summary>
+        /// Asynchronously stores to <c>dbo.MiniProfilers</c> under its <see cref="MiniProfiler.Id"/>.
+        /// </summary>
+        /// <param name="profiler">The <see cref="MiniProfiler"/> to save.</param>
+        public async override Task SaveAsync(MiniProfiler profiler)
+        {
+            using (var DbContext = GetDbContext())
+            {
+                if (!DbContext.MiniProfilers.Any(a => a.Id == profiler.Id))
+                {
+                    await DbContext.MiniProfilers.AddAsync(GetMiniProfilers(profiler));
+                }
+
+                var timings = new List<Timing>();
+                if (profiler.Root != null)
+                {
+                    profiler.Root.MiniProfilerId = profiler.Id;
+                    FlattenTimings(profiler.Root, timings);
+                }
+
+                if (timings.Any())
+                {
+                    var newtimings = timings.Where(a => !DbContext.MiniProfilerTimings.Any(b => b.Id == a.Id)).ToList();
+                    await DbContext.MiniProfilerTimings.AddRangeAsync(newtimings.Select(timing => GetMiniProfilerTimings(timing)));
+                }
+
+                if (profiler.ClientTimings?.Timings?.Any() ?? false)
+                {
+                    var newtimings = profiler.ClientTimings.Timings.Where(a => !DbContext.MiniProfilerClientTimings.Any(b => b.Id == a.Id)).ToList();
+                    await DbContext.MiniProfilerClientTimings.AddRangeAsync(newtimings.Select(timing => GetMiniProfilerClientTimings(profiler.Id, timing)));
+                }
+
+                await DbContext.SaveChangesAsync();
+            }
+        }
+
+        public async override Task<MiniProfiler> LoadAsync(Guid id)
+        {
+            using (var DbContext = GetDbContext())
+            {
+                var result = GetMiniProfiler(await DbContext.MiniProfilers.FirstOrDefaultAsync(w => w.Id == id));
+                var timings = await DbContext.MiniProfilerTimings.Where(w => w.MiniProfilerId == id).OrderBy(o => o.StartMilliseconds).Select(s => GetTiming(s)).ToListAsync();
+                var clientTimings = await DbContext.MiniProfilerClientTimings.Where(w => w.MiniProfilerId == id).OrderBy(o => o.Start).Select(s => GetClientTimings(s)).ToListAsync();
+
+                ConnectTimings(result, timings, clientTimings);
+
+                if (result != null)
+                {
+                    // HACK: stored dates are UTC, but are pulled out as local time
+                    result.Started = new DateTime(result.Started.Ticks, DateTimeKind.Utc);
+                }
+                return MapOptions(result);
+            }
+        }
+
+        /// <summary>
+        /// Loads the <c>MiniProfiler</c> identified by 'id' from the database.
+        /// </summary>
+        /// <param name="id">The profiler ID to load.</param>
+        /// <returns>The loaded <see cref="MiniProfiler"/>.</returns>
+        public override MiniProfiler Load(Guid id)
+        {
+            var task = LoadAsync(id);
+            task.Wait();
+            return task.Result;
+        }
+
+        private MiniProfiler MapOptions(MiniProfiler miniProfiler)
+        {
+            return miniProfiler == null ? null : new MiniProfiler(miniProfiler.Name, new MiniProfilerBaseOptions())
+            {
+                Id = miniProfiler.Id,
+                HasUserViewed = miniProfiler.HasUserViewed,
+                Head = miniProfiler.Head,
+                MachineName = miniProfiler.MachineName,
+                Root = miniProfiler.Root,
+                RootTimingId = miniProfiler.RootTimingId,
+                Started = miniProfiler.Started,
+                User = miniProfiler.User
+            };
+        }
+
+        /// <summary>
+        /// Sets a particular profiler session so it is considered "unviewed"  
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as unviewed for.</param>
+        /// <param name="id">The profiler ID to set unviewed.</param>
+        public override void SetUnviewed(string user, Guid id) => ToggleViewed(user, id, false);
+        /// <summary>
+        /// Asynchronously sets a particular profiler session so it is considered "unviewed"  
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as unviewed for.</param>
+        /// <param name="id">The profiler ID to set unviewed.</param>
+        public override Task SetUnviewedAsync(string user, Guid id) => ToggleViewedAsync(user, id, false);
+        /// <summary>
+        /// Sets a particular profiler session to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="id">The profiler ID to set viewed.</param>
+        public override void SetViewed(string user, Guid id) => ToggleViewed(user, id, true);
+        /// <summary>
+        /// Asynchronously sets a particular profiler session to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="id">The profiler ID to set viewed.</param>
+        public override Task SetViewedAsync(string user, Guid id) => ToggleViewedAsync(user, id, true);
+
+        public override List<Guid> GetUnviewedIds(string user)
+        {
+            using (var DbContext = GetDbContext())
+            {
+                return DbContext.MiniProfilers.Where(w => w.User == user && w.HasUserViewed == false).Select(s => s.Id).ToList();
+            }
+        }
+
+        public async override Task<List<Guid>> GetUnviewedIdsAsync(string user)
+        {
+            using (var DbContext = GetDbContext())
+            {
+                return await DbContext.MiniProfilers.Where(w => w.User == user && w.HasUserViewed == false).Select(s => s.Id).ToListAsync();
+            }
+        }
+
+        protected override DbConnection GetConnection()
+        {
+            throw new NotImplementedException();
+        }
+
+        #region Private Helper Methods...
+
+        private MiniProfiler GetMiniProfiler(MiniProfilers profiler)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return profiler == null ? null : new MiniProfiler
+            {
+                Id = profiler.Id,
+                RootTimingId = profiler.RootTimingId,
+                Name = profiler.Name.Truncate(200),
+                Started = profiler.Started,
+                DurationMilliseconds = profiler.DurationMilliseconds,
+                User = profiler.User.Truncate(100),
+                HasUserViewed = profiler.HasUserViewed,
+                MachineName = profiler.MachineName.Truncate(100),
+                CustomLinksJson = profiler.CustomLinksJson,
+                //ClientTimingsRedirectCount = profiler.
+            };
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        private Timing GetTiming(MiniProfilerTimings timing)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return timing == null ? null : new Timing
+            {
+                Id = timing.Id,
+                MiniProfilerId = timing.MiniProfilerId,
+                ParentTimingId = timing.ParentTimingId,
+                Name = timing.Name.Truncate(200),
+                DurationMilliseconds = timing.DurationMilliseconds,
+                StartMilliseconds = timing.StartMilliseconds,
+                CustomTimingsJson = timing.CustomTimingsJson
+            };
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        private ClientTiming GetClientTimings(MiniProfilerClientTimings timing)
+        {
+            return timing == null ? null : new ClientTiming
+            {
+                Id = timing.Id,
+                MiniProfilerId = timing.MiniProfilerId,
+                Name = timing.Name,
+                Start = timing.Start,
+                Duration = timing.Duration
+            };
+        }
+
+        private MiniProfilers GetMiniProfilers(MiniProfiler profiler)
+        {
+            return new MiniProfilers
+            {
+                Id = profiler.Id,
+                RootTimingId = profiler.Root?.Id,
+                Name = profiler.Name.Truncate(200),
+                Started = profiler.Started,
+                DurationMilliseconds = profiler.DurationMilliseconds,
+                User = profiler.User.Truncate(100),
+                HasUserViewed = profiler.HasUserViewed,
+                MachineName = profiler.MachineName.Truncate(100),
+                CustomLinksJson = profiler.CustomLinksJson,
+                ClientTimingsRedirectCount = profiler.ClientTimings?.RedirectCount
+            };
+        }
+
+        private MiniProfilerTimings GetMiniProfilerTimings(Timing timing)
+        {
+            return new MiniProfilerTimings
+            {
+                Id = timing.Id,
+                MiniProfilerId = timing.MiniProfilerId,
+                ParentTimingId = timing.ParentTimingId,
+                Name = timing.Name.Truncate(200),
+                DurationMilliseconds = timing.DurationMilliseconds,
+                StartMilliseconds = timing.StartMilliseconds,
+                IsRoot = timing.IsRoot,
+                Depth = timing.Depth,
+                CustomTimingsJson = timing.CustomTimingsJson
+            };
+        }
+        private MiniProfilerClientTimings GetMiniProfilerClientTimings(Guid profilerId, ClientTiming timing)
+        {
+            return new MiniProfilerClientTimings
+            {
+                Id = Guid.NewGuid(),
+                MiniProfilerId = profilerId,
+                Name = timing.Name.Truncate(200),
+                Start = timing.Start,
+                Duration = timing.Duration
+            };
+        }
+
+        private void ToggleViewed(string user, Guid id, bool hasUserViewed)
+        {
+            //var miniprofile = DbContext.MiniProfilers.FirstOrDefault(w => w.Id == id && w.User == user);
+            //if (miniprofile == null)
+            //{
+            //    return;
+            //}
+            //miniprofile.HasUserViewed = hasUserViewed;
+            //DbContext.Entry(miniprofile).State = Microsoft.EntityFrameworkCore.EntityState.Modified;
+            //DbContext.SaveChanges();
+        }
+        private Task ToggleViewedAsync(string user, Guid id, bool hasUserViewed)
+        {
+            return Task.CompletedTask;
+            //var miniprofile = DbContext.MiniProfilers.FirstOrDefault(w => w.Id == id && w.User == user);
+            //if (miniprofile == null)
+            //{
+            //    return;
+            //}
+            //miniprofile.HasUserViewed = hasUserViewed;
+            //DbContext.Entry(miniprofile).State = Microsoft.EntityFrameworkCore.EntityState.Modified;
+            //await DbContext.SaveChangesAsync();
+        }
+        #endregion Private Helper Methods.
+    }
+
+}


### PR DESCRIPTION
This PR introduces a new SQlite provider to be use for .NET Core projects.  It is structured very similar to the existing SQLite provider, except it uses Entity Framework.

However the primary motivation was to fix a "Null Reference" error which occurs within RenderIncludes function for Asp.net Core projects.  

When Storage.Load is called, the MiniProfiler.Options attribute is not "rehydrated" by any of the existing storage providers (except for memory storage provider).  This causes the null exception in RenderIncludes as mentioned.

The workaround used in this PR  was to create a new MiniProfiler with default options when Storage.Load is called.   I am not sure if there is a better way to deal with this.  

Rather than logging a bug, I hoping this PR might be better able to highlight the issue