### PR TITLE
Avoid hard-coded path to roslyn compiler

### DIFF
--- a/samples/Samples.Mvc5.EFCore/Samples.Mvc5.EFCore.csproj
+++ b/samples/Samples.Mvc5.EFCore/Samples.Mvc5.EFCore.csproj
@@ -11,7 +11,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <PostBuildEvent>
       if not exist "roslyn" md "roslyn"
-      xcopy /s /y /q "$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.1.0\tools\*.*" "roslyn"
+      xcopy /s /y /q "$(CscToolPath)\*.*" "roslyn"
     </PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/Samples.Mvc5/Samples.Mvc5.csproj
+++ b/samples/Samples.Mvc5/Samples.Mvc5.csproj
@@ -11,7 +11,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <PostBuildEvent>
       if not exist "roslyn" md "roslyn"
-      xcopy /s /y /q "$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.1.0\tools\*.*" "roslyn"
+      xcopy /s /y /q "$(CscToolPath)\*.*" "roslyn"
     </PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes the build on a fresh install of VS2017 Community