### PR TITLE
Clarified asp.net core documentation

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -64,6 +64,12 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
 {
     // ...existing configuration...
     app.UseMiniProfiler();
+
+    // The call to app.UseMiniProfiler must come before the call to app.UseMvc
+    app.UseMvc(routes =>
+    {
+        // ...
+    });
 }
 ```
 <sub>Note: most of the above are optional. A config can be as minimal as `app.UseMiniProfiler(new MiniProfilerOptions()));`</sub>


### PR DESCRIPTION
It took me a while to figure out why following the instructions on https://miniprofiler.com/dotnet/AspDotNetCore did not work in my ASP.NET Core 2.0 MVC application.

Since the documentation said 
```
public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory, IMemoryCache cache)
{
    // ...existing configuration...
    app.UseMiniProfiler();
}
```
I had added this line at the end of the Configure method.
Turns out that it needs to precede the call to app.UseMvc or it will not work.

"Not work" meaning:
The script tag is added to the html  
but the script which it tries to load is not available