### PR TITLE
Expose disposed inner connection

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
@@ -160,7 +160,6 @@ namespace StackExchange.Profiling.Data
                 _connection.Dispose();
             }
             base.Dispose(disposing);
-            _connection = null;
             _profiler = null;
         }
 


### PR DESCRIPTION
Fixes #243. At some point IDbProviderFactoryResolver is asked to resolve a factory for a disposed profiled connection. The profiled implementation of this interface unwraps the profiled connection and passes the inner connection to the actual factory resolver. This caused "Value cannot be null. Parameter name: connection" because the inner connection was null after disposing. I don't see why the inner connection should be set to null after disposing, as it can still be useful. Such as for resolving factories based on connections.