### PR TITLE
Support for Entity Framework 6.2.0

### DIFF
--- a/src/MiniProfiler.EF6/EFProfiledDbProviderServices.cs
+++ b/src/MiniProfiler.EF6/EFProfiledDbProviderServices.cs
@@ -164,5 +164,26 @@ namespace StackExchange.Profiling.Data
         /// <param name="value">The value of the parameter.</param>
         protected override void SetDbParameterValue(DbParameter parameter, TypeUsage parameterType, object value) =>
             _tail.SetParameterValue(parameter, parameterType, value);
+
+        /// <summary>
+        /// Clones the connection.
+        /// </summary>
+        /// <param name="connection">The original connection.</param>
+        /// <returns></returns>
+        public override DbConnection CloneDbConnection(DbConnection connection) =>
+            connection is ProfiledDbConnection profiled
+                ? new ProfiledDbConnection(base.CloneDbConnection(profiled.WrappedConnection), profiled.Profiler)
+                : base.CloneDbConnection(connection);
+
+        /// <summary>
+        /// Clones the connection.
+        /// </summary>
+        /// <param name="connection">The original connection.</param>
+        /// <param name="factory">The factory to use.</param>
+        /// <returns>Cloned connection</returns>
+        public override DbConnection CloneDbConnection(DbConnection connection, DbProviderFactory factory) =>
+            connection is ProfiledDbConnection profiled
+                ? new ProfiledDbConnection(base.CloneDbConnection(profiled.WrappedConnection, factory), profiled.Profiler)
+                : base.CloneDbConnection(connection, factory);
     }
 }

--- a/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
+++ b/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
-    <PackageReference Include="EntityFramework" Version="6.1.3" />
+    <PackageReference Include="EntityFramework" Version="6.2.0" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
   </ItemGroup>


### PR DESCRIPTION
EF 6.2.0 adds two new methods to `DbProviderServices` that must be overridden to correctly unwrap the `ProfiledDbConnection`.

This should resolve #243