### PR TITLE
Update includes.js to prefer standardized timing APIs instead of deprecated ones

### DIFF
--- a/src/MiniProfiler.Shared/ui/includes.js
+++ b/src/MiniProfiler.Shared/ui/includes.js
@@ -106,14 +106,27 @@ var MiniProfiler = (function () {
                     }
                     clientPerformance = copy;
 
-                    // hack to add chrome timings
-                    if (window.chrome && window.chrome.loadTimes) {
+                    if (window.performance.getEntriesByType && window.PerformancePaintTiming && performance.timeOrigin) {
+                        var entries = window.performance.getEntriesByType('paint');
+                        for (var i = 0; i < entries.length; i++) {
+                            var entry = entries[i];
+                            switch (entry.name) {
+                                case 'first-paint':
+                                    clientPerformance.timing['First Paint Time'] = Math.round((entry.startTime + performance.timeOrigin) / 1000);
+                                    break;
+                                case 'first-contentful-paint':
+                                    clientPerformance.timing['First Contentful Paint Time'] = Math.round((entry.startTime + performance.timeOrigin) / 1000);
+                                break;
+                            }
+                        }
+                    } else if (window.chrome && window.chrome.loadTimes) {
+                      // hack to add chrome timings
                       var chromeTimes = window.chrome.loadTimes();
                       if (chromeTimes.firstPaintTime) {
-                        clientPerformance.timing['First Paint Time'] = Math.round(chromeTimes.firstPaintTime * 1000);
+                          clientPerformance.timing['First Paint Time'] = Math.round(chromeTimes.firstPaintTime * 1000);
                       }
                       if (chromeTimes.firstPaintTime) {
-                        clientPerformance.timing['First Paint After Load Time'] = Math.round(chromeTimes.firstPaintAfterLoadTime * 1000);
+                          clientPerformance.timing['First Paint After Load Time'] = Math.round(chromeTimes.firstPaintAfterLoadTime * 1000);
                       }
 
                     }
@@ -756,7 +769,7 @@ var MiniProfiler = (function () {
 
             for (var i = 0; i < clientTimings.Timings.length; i++) {
                 t = clientTimings.Timings[i];
-                var trivial = t.Name != 'Dom Complete' && t.Name != 'Response' && t.Name != 'First Paint Time';
+                var trivial = t.Name != 'Dom Complete' && t.Name != 'Response' && t.Name != 'First Paint Time' && t.Name != 'First Contentful Paint Time';
                 trivial = t.Duration < 2 ? trivial : false;
                 list.push(
                 {


### PR DESCRIPTION
Includes.js is using the window.chrome.loadTimes() API which has been marked as deprecated in the latest Chrome version and warns about it in the console.

``[Deprecation] chrome.loadTimes() is deprecated, instead use standardized API: Paint Timing.``

This PR first checks if the new API is available (it is from Chrome 60) or it will fall back to the old deprecated one.

The new API doesn't support ``firstPaintAfterLoadTime`` though but it seems that like [Chrome never did](https://developers.google.com/web/updates/2017/12/chrome-loadtimes-deprecated#firstpaintafterloadtime) anyway. It does however add "first-contentful-paint" which is a way more interesting value to keep track of.