### PR TITLE
Use HTML escape instead of javascript escape function

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -377,8 +377,8 @@ namespace StackExchange.Profiling {
                         data.forEach((profiler) => {
                             str += (`
 <tr>
-  <td><a href="${options.path}results?id=${profiler.Id}">${escape(profiler.Name)}</a></td>
-  <td>${escape(profiler.MachineName)}</td>
+  <td><a href="${options.path}results?id=${profiler.Id}">${mp.htmlEscape(profiler.Name)}</a></td>
+  <td>${mp.htmlEscape(profiler.MachineName)}</td>
   <td class="mp-results-index-date">${profiler.Started}</td>
   <td>${profiler.DurationMilliseconds}</td>` + (profiler.ClientTimings ? `
   <td>${getTiming(profiler, 'requestStart').Start}</td>
@@ -623,15 +623,17 @@ namespace StackExchange.Profiling {
             return result;
         }
 
+        private htmlEscape = (orig: string) => orig
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+
         private renderProfiler = (json: IProfiler) => {
             const p = this.processJson(json);
             const mp = this;
-            const encode = (orig: string) => orig
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;')
-                    .replace(/"/g, '&quot;')
-                    .replace(/'/g, '&#039;');
+            const encode = this.htmlEscape;
             const duration = (milliseconds: number | undefined, decimalPlaces?: number) => {
                 if (milliseconds === undefined) {
                     return '';


### PR DESCRIPTION
Currently, If I use URL as profiler name I get to see eg. `http%3A//localhost%3A53168/` in `results-index` page.

I have replaced javascript [escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) function, which is is unnecessarily strict, with HTML escape function.