### PR TITLE
Fixing JavaScript issue when StackTraceSnippet property is undefined

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -812,7 +812,7 @@ namespace StackExchange.Profiling {
               </td>
               <td>
                 <div class="query">
-                  <div class="mp-stack-trace">${encode(ct.StackTraceSnippet)}</div>
+                  <div class="mp-stack-trace">${encode(ct.StackTraceSnippet || '')}</div>
                   <pre><code>${encode(ct.CommandString)}</code></pre>
                 </div>
               </td>


### PR DESCRIPTION
When `options.ExcludeStackTraceSnippetFromCustomTimings = true;`, the `StackTraceSnippet` of the custom timing is null. The null value is omitted from the emitted JSON.

Results in `Uncaught TypeError: Cannot read property 'replace' of undefined` when attempting to HTML encode the property.