### PR TITLE
Display "show trivials" when any client timing is trivial

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -734,6 +734,8 @@ namespace StackExchange.Profiling {
                         width: null,
                     };
                 });
+                p.HasTrivialTimings = p.HasTrivialTimings || list.some((t) => t.isTrivial);
+
                 list.sort((a, b) => a.start - b.start);
                 list.forEach((l) => {
                     const percent = (100 * l.start / end) + '%';


### PR DESCRIPTION
Currently, when all _server_ timings are not trivial, the `show trivials` link is hidden even if there is trivial client timings