### PR TITLE
Added custom init condition

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -254,6 +254,7 @@ namespace StackExchange.Profiling {
         private savedJson: IProfiler[] = [];
         private path: string;
         public highlight = (elem: HTMLElement): void => undefined;
+        public initCondition: () => boolean;
 
         public init = (): MiniProfiler => {
             this.jq = jQuery.noConflict(true);
@@ -339,7 +340,8 @@ namespace StackExchange.Profiling {
             let alreadyDone = false;
             const deferInit = () => {
                 if (!alreadyDone) {
-                    if (window.performance && window.performance.timing && window.performance.timing.loadEventEnd === 0 && wait < 10000) {
+                    if ((mp.initCondition && !mp.initCondition())
+                        || (window.performance && window.performance.timing && window.performance.timing.loadEventEnd === 0 && wait < 10000)) {
                         setTimeout(deferInit, 100);
                         wait += 100;
                     } else {

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -254,7 +254,7 @@ namespace StackExchange.Profiling {
         private savedJson: IProfiler[] = [];
         private path: string;
         public highlight = (elem: HTMLElement): void => undefined;
-        public initCondition: () => boolean;
+        public initCondition: () => boolean; // Example usage: window.MiniProfiler.initCondition = function() { return myOtherThingIsReady; };
 
         public init = (): MiniProfiler => {
             this.jq = jQuery.noConflict(true);


### PR DESCRIPTION
I would like to be able to override init condition. Sometimes the *PopupView* is displayed earlier than all my client timings are finished.

eg.: 
![image](https://user-images.githubusercontent.com/656406/40943390-28cabe82-6851-11e8-911c-d879ed5e53c1.png)
In this example, I'd like to show *PopupView* after DotVVM is initialized. Sometimes it displays the *PopupView* before DotVVM initialization end. 

I'm not sure If I do something wrong or If I use it the way it was not intended to.