### PR TITLE
Fix showControls when jQuery is not included

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -971,6 +971,7 @@ namespace StackExchange.Profiling {
         }
 
         private initControls = (container: JQuery) => {
+            const $ = this.jq;
             if (this.options.showControls) {
                 this.controls = $('<div class="mp-controls"><span class="mp-min-max">m</span><span class="mp-clear">c</span></div>').appendTo(container);
 


### PR DESCRIPTION
If you don't already include jQuery in your page and use the `show-controls="true"` option you get the following error:
```
Uncaught TypeError: $ is not a function
    at n.initControls (includes.min.js?v=4.0.0+g9bca957cdc:2)
....
```