### PR TITLE
Fixed broken generation of CSS classes on mp-result element

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -831,7 +831,7 @@ namespace StackExchange.Profiling {
             }
 
             return mp.jq(`
-  <div class="mp-result${(this.options.showTrivial ? 'show-trivial' : '')}${(this.options.showChildrenTime ? 'show-columns' : '')}">
+  <div class="mp-result${(this.options.showTrivial ? ' show-trivial' : '')}${(this.options.showChildrenTime ? ' show-columns' : '')}">
     <div class="mp-button" title="${encode(p.Name)}">
       <span class="mp-number">${duration(p.DurationMilliseconds)} <span class="mp-unit">ms</span></span>
       ${(p.HasDuplicateCustomTimings ? '<span class="mp-warning">!</span>' : '')}


### PR DESCRIPTION
I stumbled upon this problem after upgrading to latest version. CSS classes are being joined without any separators what brakes it a bit due to JS not being able to select right elements. I fixed it by adding default space prior to any new CSS class being added.

![image](https://user-images.githubusercontent.com/8421443/41103511-3c3de770-6a61-11e8-88f2-4f3214b2b34c.png)
