### PR TITLE
Fix NullReferenceException when RemoteIpAddress is null

### DIFF
--- a/src/MiniProfiler.AspNetCore/MiniProfilerOptions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerOptions.cs
@@ -39,6 +39,6 @@ namespace StackExchange.Profiling
         /// <summary>
         /// Function to provide the unique user ID based on the request, to store MiniProfiler IDs user
         /// </summary>
-        public Func<HttpRequest, string> UserIdProvider { get; set; } = request => request.HttpContext.Connection.RemoteIpAddress.ToString();
+        public Func<HttpRequest, string> UserIdProvider { get; set; } = request => request.HttpContext.Connection.RemoteIpAddress?.ToString();
     }
 }


### PR DESCRIPTION
Which is the case when invoking the middleware from integration tests using `Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<T>`. An example test is:

```
public class TelemetryFunctionalTests
    {
        public WebApplicationFactory<Program> Factory { get; }

        public TelemetryFunctionalTests(WebApplicationFactory<Program> factory)
        {
            Factory = factory;
        }

        [Fact]
        public async Task Get()
        {
            var client = Factory.CreateClient();

            var telemetry = await Client.GetAsync("/Telemetry");

            Assert.NotNull(telemetry);
        }
    }
```

This will currently throw a `NullReferenceException`  at https://github.com/MiniProfiler/dotnet/blob/master/src/MiniProfiler.AspNetCore/MiniProfilerOptions.cs#L42