### PR TITLE
ProfiledDbCommand does not set connection for wrapped command

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -54,7 +54,11 @@ namespace StackExchange.Profiling.Data
         {
             _command = command ?? throw new ArgumentNullException(nameof(command));
 
-            UnwrapAndAssignConnection(connection);
+            if (connection != null)
+            {
+                _connection = connection;
+                UnwrapAndAssignConnection(connection);
+            }
 
             if (profiler != null)
             {

--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -53,7 +53,8 @@ namespace StackExchange.Profiling.Data
         public ProfiledDbCommand(DbCommand command, DbConnection connection, IDbProfiler profiler)
         {
             _command = command ?? throw new ArgumentNullException(nameof(command));
-            _connection = connection;
+
+            UnwrapAndAssignConnection(connection);
 
             if (profiler != null)
             {
@@ -137,15 +138,20 @@ namespace StackExchange.Profiling.Data
             set
             {
                 _connection = value;
-                if (value is ProfiledDbConnection profiledConn)
-                {
-                    _profiler = profiledConn.Profiler;
-                    _command.Connection = profiledConn.WrappedConnection;
-                }
-                else
-                {
-                    _command.Connection = value;
-                }
+                UnwrapAndAssignConnection(value);
+            }
+        }
+
+        private void UnwrapAndAssignConnection(DbConnection value)
+        {
+            if (value is ProfiledDbConnection profiledConn)
+            {
+                _profiler = profiledConn.Profiler;
+                _command.Connection = profiledConn.WrappedConnection;
+            }
+            else
+            {
+                _command.Connection = value;
             }
         }
 

--- a/tests/MiniProfiler.Tests/DbProfilerTests.cs
+++ b/tests/MiniProfiler.Tests/DbProfilerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
@@ -149,6 +150,21 @@ namespace StackExchange.Profiling.Tests
                 Assert.Equal(1, profiler.ReaderFinishCount);
                 Assert.True(profiler.CompleteStatementMeasured);
 #endif
+            }
+        }
+
+        [Fact]
+        public void DataReaderViaProfiledDbCommandWithNullConnection()
+        {
+            // https://github.com/MiniProfiler/dotnet/issues/313
+
+            using (var conn = GetConnection())
+            {
+                var command = new SqliteCommand("select 1");
+                var wrappedCommand = new ProfiledDbCommand(command, conn, conn.Profiler);
+
+                var reader = wrappedCommand.ExecuteReader(CommandBehavior.SequentialAccess);
+                Assert.True(reader.Read());
             }
         }
 


### PR DESCRIPTION
See: https://github.com/MiniProfiler/dotnet/issues/313
