### PR TITLE
Propagate Dispose from ProfiledDbDataReader

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
@@ -232,5 +232,19 @@ namespace StackExchange.Profiling.Data
         /// <returns>A <see cref="DataTable"/> that describes the column metadata.</returns>
         public override DataTable GetSchemaTable() => WrappedReader.GetSchemaTable();
 #endif
+        // <summary>Disposes the IDataReader Object.</summary>
+        protected override void Dispose(bool disposing)
+        {
+            // reader can be null when we're not profiling, but we've inherited from ProfiledDbCommand and are returning a
+            // an unwrapped reader from the base command
+            WrappedReader?.Dispose();
+#if NETSTANDARD1_5
+            // Close isn't available in NETSTANDARD1_5, but Dispose *is*.
+            // Dispose should call close anyway, so we aren't calling ReaderFinish for other frameworks
+            _profiler?.ReaderFinish(this);
+#endif
+            
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/MiniProfiler.Tests/DbProfilerTests.cs
+++ b/tests/MiniProfiler.Tests/DbProfilerTests.cs
@@ -116,13 +116,8 @@ namespace StackExchange.Profiling.Tests
 
                 Assert.Equal(1, profiler.ExecuteStartCount);
                 Assert.Equal(1, profiler.ExecuteFinishCount);
-#if NETCOREAPP1_1 // .Close() is not exposed in netstandard1.5
-                Assert.Equal(0, profiler.ReaderFinishCount);
-                Assert.False(profiler.CompleteStatementMeasured);
-#else
                 Assert.Equal(1, profiler.ReaderFinishCount);
                 Assert.True(profiler.CompleteStatementMeasured);
-#endif
             }
         }
 
@@ -143,13 +138,8 @@ namespace StackExchange.Profiling.Tests
 
                 Assert.Equal(1, profiler.ExecuteStartCount);
                 Assert.Equal(1, profiler.ExecuteFinishCount);
-#if NETCOREAPP1_1 // .Close() is not exposed in netstandard1.5
-                Assert.Equal(0, profiler.ReaderFinishCount);
-                Assert.False(profiler.CompleteStatementMeasured);
-#else
                 Assert.Equal(1, profiler.ReaderFinishCount);
                 Assert.True(profiler.CompleteStatementMeasured);
-#endif
             }
         }
 


### PR DESCRIPTION
I'm having issues with Npgsql and linq2db without calling Dispose on the actual reader.

It also fixes missing ReaderFinish call on netcoreapp1.1 if `Dispose` is being used to close the data reader.