### PR TITLE
Handle Exception in DataReader (Fire OnError event)

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -199,8 +199,8 @@ namespace StackExchange.Profiling.Data
         /// <summary>
         /// Creates a wrapper data reader for <see cref="ExecuteDbDataReader"/> and <see cref="ExecuteDbDataReaderAsync"/> />
         /// </summary>
-        protected virtual DbDataReader CreateDbDataReader(DbDataReader original, IDbProfiler profiler)
-            => new ProfiledDbDataReader(original, profiler);
+        protected virtual DbDataReader CreateDbDataReader(DbDataReader original, IDbCommand command, IDbProfiler profiler)
+            => new ProfiledDbDataReader(original, command, profiler);
         
         /// <summary>
         /// Executes a database data reader.
@@ -219,7 +219,7 @@ namespace StackExchange.Profiling.Data
             try
             {
                 result = _command.ExecuteReader(behavior);
-                result = CreateDbDataReader(result, _profiler);
+                result = CreateDbDataReader(result, _command, _profiler);
             }
             catch (Exception e)
             {
@@ -252,7 +252,7 @@ namespace StackExchange.Profiling.Data
             try
             {
                 result = await _command.ExecuteReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
-                result = CreateDbDataReader(result, _profiler);
+                result = CreateDbDataReader(result, _command, _profiler);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Some SQL command may failed in DataReader. For example, following SQL script:

```
INSERT INTO [dbo].[Demo] ([Name]) OUTPUT INSERTED.ID VALUES ('ABCD')
INSERT INTO [dbo].[Demo] ([Name]) OUTPUT INSERTED.ID VALUES ('ABCD')
```
The second one will failed to execute since NAME column has an unique index on it.

This fix will handle this error and call OnError function to capture it.