### PR TITLE
ProfiledDbConnection's methods after Dispose shouldn't all throw NullReferenceException

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
@@ -163,7 +163,6 @@ namespace StackExchange.Profiling.Data
                 _connection.Dispose();
             }
             base.Dispose(disposing);
-            _connection = null;
             _profiler = null;
         }
 


### PR DESCRIPTION
After I call `MiniProfilerEF6.Initialize()` then my automatic migrations fail. This is because when EF6 `System.Data.Entity.Internal.RepositoryBase.CreateConnection` (https://github.com/aspnet/EntityFramework6/blob/6.2.0/src/EntityFramework/Internal/RepositoryBase.cs#L35) is called, it checks the connections's State which, if the connection has been Disposed, throws a NullReferenceException because `_connection` gets null-ed on Dispose. 

This isn't the right behaviour for a DbConnection. If you `Close` a `SqlConnection` for example, you can still call members such as `State` and they don't throw. I therefore propose the `_connection` is left as-is so that the wrapped methods still delegate to it without throwing  `NullReferenceExceptions`.