### PR TITLE
MongoDB: Use database from connection string when set

### DIFF
--- a/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
+++ b/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
@@ -26,9 +26,12 @@ namespace StackExchange.Profiling
                 BsonClassMapFields();
             }
 
-            _client = new MongoClient(connectionString);
+            var url = new MongoUrl(connectionString);
+            var databaseName = url.DatabaseName ?? "MiniProfiler";
+
+            _client = new MongoClient(url);
             _collection = _client
-                .GetDatabase("MiniProfiler")
+                .GetDatabase(databaseName)
                 .GetCollection<MiniProfiler>("profilers");
         }
 

--- a/tests/MiniProfiler.Tests/Storage/MongoDbStorageTests.cs
+++ b/tests/MiniProfiler.Tests/Storage/MongoDbStorageTests.cs
@@ -46,7 +46,8 @@ namespace StackExchange.Profiling.Tests.Storage
         /// <param name="storage">The storage to drop schema for.</param>
         public static void DropDatabase(this MongoDbStorage storage)
         {
-            storage.GetClient().DropDatabase("MiniProfiler");
+            var url = new MongoDB.Driver.MongoUrl(TestConfig.Current.MongoDbConnectionString);
+            storage.GetClient().DropDatabase(url.DatabaseName);
         }
     }
 }


### PR DESCRIPTION
Will still default to "MiniProfiler" when not set but otherwise will use the database as defined from the connection string.