### PR TITLE
Update ExtensionMethods.cs

### DIFF
--- a/src/MiniProfiler.Shared/Internal/ExtensionMethods.cs
+++ b/src/MiniProfiler.Shared/Internal/ExtensionMethods.cs
@@ -79,6 +79,7 @@ namespace StackExchange.Profiling.Internal
         private static readonly JsonSerializerSettings defaultSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
+            TypeNameHandling = TypeNameHandling.None,
             ContractResolver = new DefaultContractResolver()
         };
 
@@ -86,6 +87,7 @@ namespace StackExchange.Profiling.Internal
         {
             StringEscapeHandling = StringEscapeHandling.EscapeHtml,
             NullValueHandling = NullValueHandling.Ignore,
+            TypeNameHandling = TypeNameHandling.None,
             ContractResolver = new DefaultContractResolver()
         };
 


### PR DESCRIPTION
Added explicit setting for TypeNameHandling in the JsonSerializerSettings to prevent overridden defaults from causing breaking changes to the MiniProfiler. Related to #337 