### PR TITLE
Add Support for Azure DevOps Builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,67 @@
+resources:
+- repo: self
+  clean: true
+queue:
+  name: Hosted VS2017
+
+# Build Variables
+variables:
+  MySQLConnectionString: server=localhost;uid=root;pwd='';database=test;Allow User Variables=true
+  PGPASSWORD: Password12! #Needed for PostgreSQL Installation
+  PGUSER: postgres #Needed for PostgreSQL Installation
+  PostgreSqlConnectionString: Server=localhost;Port=5432;Database=test;User Id=postgres;Password=Password12!;
+  SQLServerConnectionString: Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=tempdb;Trusted_Connection=True;
+  system.debug: true
+
+# CI Trigger on master branch
+trigger:
+  batch: false
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - docs/*
+    - '**/*.md'    
+
+# Trigger builds for PR's targeting master 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - docs/*
+    - '**/*.md' 
+
+steps:
+- task: DotNetCoreInstaller@0
+  displayName: 'Install DotNet Core 2.1.3'
+  inputs:
+    version: 2.1.300
+
+- task: NuGetToolInstaller@0
+  displayName: 'Install NuGet CLI 4.4.1'
+  inputs:
+    versionSpec: 4.4.1
+
+- task: PowerShell@2
+  displayName: 'Build / Test / Create Packages'
+  inputs:
+    targetType: filePath
+    filePath: build.AzureDevops.ps1
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results **/Test-*.xml'
+  inputs:
+    testResultsFormat: XUnit
+    testResultsFiles: '**/Test-*.xml'
+    mergeTestResults: true
+
+# PR doesn't create nuget packages. So publish artifact step disabled for PR's
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: packages'
+  inputs:
+    PathtoPublish: .nupkgs
+    ArtifactName: packages
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build.azureDevops.ps1
+++ b/build.azureDevops.ps1
@@ -1,0 +1,26 @@
+# Setup Redis with Nuget
+nuget install redis-64 -excludeversion
+redis-64\tools\redis-server.exe --service-install; redis-64\tools\redis-server.exe --service-start
+
+# Setup PostgreSQL, MySQL, MongoDB using Chocolatey
+choco feature enable -n=allowGlobalConfirmation
+choco install mongodb --version 3.6.0
+choco install mysql --version 5.7.18 
+choco install postgresql --version 9.6.8 --params "/Password:$PGPASSWORD"
+
+# Chocolatey profile
+$ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+if (Test-Path($ChocolateyProfile)) {
+    Import-Module "$ChocolateyProfile"
+}
+refreshenv
+
+mysql -e "create database test;" --user=root
+createdb test 
+
+mkdir D:\data\db
+# Start MongoDB as run as Background Process
+Start-Process "C:\Program Files\MongoDB\Server\3.6\bin\mongod.exe" -ArgumentList "--dbpath D:\data\db" -NoNewWindow -RedirectStandardOutput log.txt
+
+# Build Variables at https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=vsts#build-variables
+.\build.ps1 -CreatePackages $true -PullRequestNumber $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER

--- a/build.ps1
+++ b/build.ps1
@@ -45,7 +45,7 @@ if ($RunTests) {
         Write-Host "Running tests: $project (all frameworks)" -ForegroundColor "Magenta"
         Push-Location ".\tests\$project"
 
-        dotnet xunit -configuration Release --no-build
+        dotnet xunit -configuration Release --no-build -xml "Test-$project.xml"
         if ($LastExitCode -ne 0) {
             Write-Host "Error with tests, aborting build." -Foreground "Red"
             Pop-Location


### PR DESCRIPTION
# Add Support for Azure Pipelines #338 
You can see the builds at https://dev.azure.com/agileguru/MiniProfiler/_build?definitionId=48&_a=summary

The build is triggered for every push to master and PR's targeting master.
The build process spins up 
- Redis
- MySQL
- PostgreSQL
- MongoDB 
- SQL Server (LocalDB)

## Build Artifacts
The Build publishes Build Artifacts (not to be confused with Azure Artifacts) only for CI Builds (in master) and not for PR's.
![artifacts](https://user-images.githubusercontent.com/21144140/50545228-0350c080-0c33-11e9-9723-9f3ea10f6be2.png)

 
## Tests 
![4 0 151 gurucharan94 dotnet](https://user-images.githubusercontent.com/21144140/50545178-05b21b00-0c31-11e9-8755-fd32774343c7.png)

**12 SQL Server Tests are skipped with below message**
`Couldn't test against: StackExchange.Profiling.Storage.SqlServerStorage\nThe type initializer for 'System.Data.SqlClient.TdsParser' threw an exception.
`
