### PR TITLE
Fix thread safe issue

### DIFF
--- a/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
@@ -28,6 +28,9 @@ namespace StackExchange.Profiling
             lock (_dbLocker)
             {
                 _inProgress = _inProgress ?? new Dictionary<Tuple<object, SqlExecuteType>, CustomTiming>();
+            }
+            lock (_inProgress)
+            {
                 _inProgress[id] = timing;
             }
         }
@@ -47,7 +50,7 @@ namespace StackExchange.Profiling
 
             var id = Tuple.Create((object)profiledDbCommand, executeType);
             CustomTiming current;
-            lock (_dbLocker)
+            lock (_inProgress)
             {
                 if (!_inProgress.TryRemove(id, out current))
                 {
@@ -60,6 +63,9 @@ namespace StackExchange.Profiling
                 lock (_dbLocker)
                 {
                     _inProgressReaders = _inProgressReaders ?? new Dictionary<IDataReader, CustomTiming>();
+                }
+                lock (_inProgressReaders)
+                {
                     _inProgressReaders[reader] = current;
                 }
                 current.FirstFetchCompleted();

--- a/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
@@ -47,7 +47,7 @@ namespace StackExchange.Profiling
 
             var id = Tuple.Create((object)profiledDbCommand, executeType);
             CustomTiming current;
-            lock (_inProgress)
+            lock (_dbLocker)
             {
                 if (!_inProgress.TryRemove(id, out current))
                 {


### PR DESCRIPTION
Lock was acquired for dictionary object, but not for _dbLocker and because of this, the dictionary was broken if methods ExecuteStart and ExecuteFinish were called from different threads.