### PR TITLE
CreateDbDataReader should expose the originally requested CommandBehavior

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -201,7 +201,13 @@ namespace StackExchange.Profiling.Data
         /// </summary>
         protected virtual DbDataReader CreateDbDataReader(DbDataReader original, IDbProfiler profiler)
             => new ProfiledDbDataReader(original, profiler);
-        
+
+        /// <summary>
+        /// Creates a wrapper data reader for <see cref="ExecuteDbDataReader"/> and <see cref="ExecuteDbDataReaderAsync"/> />
+        /// </summary>
+        protected virtual DbDataReader CreateDbDataReader(DbDataReader original, CommandBehavior behavior, IDbProfiler profiler)
+            => CreateDbDataReader(original, profiler); // call the v1 API that lacked the behavior, so pre-existing overrides work correctly
+
         /// <summary>
         /// Executes a database data reader.
         /// </summary>
@@ -219,7 +225,7 @@ namespace StackExchange.Profiling.Data
             try
             {
                 result = _command.ExecuteReader(behavior);
-                result = CreateDbDataReader(result, _profiler);
+                result = CreateDbDataReader(result, behavior, _profiler);
             }
             catch (Exception e)
             {
@@ -252,7 +258,7 @@ namespace StackExchange.Profiling.Data
             try
             {
                 result = await _command.ExecuteReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
-                result = CreateDbDataReader(result, _profiler);
+                result = CreateDbDataReader(result, behavior, _profiler);
             }
             catch (Exception e)
             {

--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -199,14 +199,8 @@ namespace StackExchange.Profiling.Data
         /// <summary>
         /// Creates a wrapper data reader for <see cref="ExecuteDbDataReader"/> and <see cref="ExecuteDbDataReaderAsync"/> />
         /// </summary>
-        protected virtual DbDataReader CreateDbDataReader(DbDataReader original, IDbProfiler profiler)
-            => new ProfiledDbDataReader(original, profiler);
-
-        /// <summary>
-        /// Creates a wrapper data reader for <see cref="ExecuteDbDataReader"/> and <see cref="ExecuteDbDataReaderAsync"/> />
-        /// </summary>
         protected virtual DbDataReader CreateDbDataReader(DbDataReader original, CommandBehavior behavior, IDbProfiler profiler)
-            => CreateDbDataReader(original, profiler); // call the v1 API that lacked the behavior, so pre-existing overrides work correctly
+            => new ProfiledDbDataReader(original, profiler);
 
         /// <summary>
         /// Executes a database data reader.

--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -200,7 +200,7 @@ namespace StackExchange.Profiling.Data
         /// Creates a wrapper data reader for <see cref="ExecuteDbDataReader"/> and <see cref="ExecuteDbDataReaderAsync"/> />
         /// </summary>
         protected virtual DbDataReader CreateDbDataReader(DbDataReader original, CommandBehavior behavior, IDbProfiler profiler)
-            => new ProfiledDbDataReader(original, profiler);
+            => new ProfiledDbDataReader(original, behavior, profiler);
 
         /// <summary>
         /// Executes a database data reader.

--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
@@ -15,7 +15,7 @@ namespace StackExchange.Profiling.Data
         private readonly IDbProfiler _profiler;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProfiledDbDataReader"/> class.
+        /// Initializes a new instance of the <see cref="ProfiledDbDataReader"/> class (with <see cref="CommandBehavior.Default"/>).
         /// </summary>
         /// <param name="reader">The reader.</param>
         /// <param name="profiler">The profiler.</param>

--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
@@ -19,15 +19,23 @@ namespace StackExchange.Profiling.Data
         /// </summary>
         /// <param name="reader">The reader.</param>
         /// <param name="profiler">The profiler.</param>
-        public ProfiledDbDataReader(DbDataReader reader, IDbProfiler profiler)
+        public ProfiledDbDataReader(DbDataReader reader, IDbProfiler profiler) : this(reader, CommandBehavior.Default, profiler) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfiledDbDataReader"/> class.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        /// <param name="behavior">The behavior specified during command execution.</param>
+        /// <param name="profiler">The profiler.</param>
+        public ProfiledDbDataReader(DbDataReader reader, CommandBehavior behavior, IDbProfiler profiler)
         {
             WrappedReader = reader;
-
-            if (profiler != null)
-            {
-                _profiler = profiler;
-            }
+            Behavior = behavior;
+            _profiler = profiler;
         }
+
+        /// <summary>Gets the behavior specified during command execution.</summary>
+        public CommandBehavior Behavior { get; }
 
         /// <summary>Gets a value indicating the depth of nesting for the current row.</summary>
         public override int Depth => WrappedReader.Depth;


### PR DESCRIPTION
Context: subclasses of `ProfiledDbCommand` may need to be aware of the `CommandBehavior` if they are providing a custom subclass of `ProfiledDbDataReader`, especially if they want to perform connection status tracking such as closure tracking.

Change: add `CommandBehavior behavior` as a parameter into the `CreateDbDataReader` method, that has not been released in RTM form yet.