### PR TITLE
Updated isoDate regex to make micro seconds optional

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -415,7 +415,7 @@ namespace StackExchange.Profiling {
                     continue; // already fetching
                 }
 
-                const isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+                const isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)(?:Z|(\+|-)([\d|:]*))?$/;
                 const parseDates = (key: string, value: any) =>
                           key === 'Started' && typeof value === 'string' && isoDate.exec(value) ? new Date(value) : value;
 


### PR DESCRIPTION
Updated isoDate regex to make micro settings optional, fixing an possible issue with the lack of precision returned by MySQL.

Full details can be found in this issue #370 

This fix has been tested in isolation with a number of iso dates without micro seconds, the full repo hasn't been built or tested unfortunately. 