### PR TITLE
Exposed End Points Added to Documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,12 @@ Note the share link for sharing timings with other team members. Any custom timi
 #### Minimum requirements
 MiniProfiler v4 runs on .NET 4.6 and above or .NET Standard 1.5 and above. .NET 4.6+ is required due to all of the `async` support added in v4. If you need to use a version earlier than .NET 4.6, MiniProfiler v3.x is for you.
 
+#### White Listing
+MiniProfiler exposes the following end points for profiling:
+- /results-index
+- /results-list
+- /results
+
 #### Links
 * The MiniProfiler for .NET GitHub repo [is located at MiniProfiler/dotnet](https://github.com/MiniProfiler/dotnet).
 * We accept [pull requests](https://github.com/MiniProfiler/dotnet/pulls) here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,9 @@ MiniProfiler v4 runs on .NET 4.6 and above or .NET Standard 1.5 and above. .NET 
 
 #### White Listing
 MiniProfiler exposes the following end points for profiling:
-- /results-index
-- /results-list
-- /results
+* /results-index
+* /results-list
+* /results
 
 #### Links
 * The MiniProfiler for .NET GitHub repo [is located at MiniProfiler/dotnet](https://github.com/MiniProfiler/dotnet).


### PR DESCRIPTION
Addressing Issue #342
 
Looked at the ProcessRequest method in MiniProfilerHandler. I added it to the overview page as the routes don't changed based on framework and thus should be on a shared page. Further, creating a separate page seemed unwarranted for the amount of information.

Any other content that should be covered or any routes that I missed?