### PR TITLE
Fixing typo in AspDotNet.md

### DIFF
--- a/docs/AspDotNet.md
+++ b/docs/AspDotNet.md
@@ -68,7 +68,7 @@ protected void Application_Start()
     .ExcludeType("SessionFactory")  // Ignore any class with the name of SessionFactory)
     .ExcludeAssembly("NHibernate")  // Ignore any assembly named NHibernate
     .ExcludeMethod("Flush")         // Ignore any method with the name of Flush
-    .AddViewPofiling()              // Add MVC view profiling (you want this)
+    .AddViewProfiling()              // Add MVC view profiling (you want this)
     // If using EntityFrameworkCore, here's where it'd go.
     // .AddEntityFramework()        // Extension method in the MiniProfiler.EntityFrameworkCore package
     );


### PR DESCRIPTION
"AddViewProfiling" vs "AddViewPofiling". Looks like this spelling was corrected in the sample itself, but not in the docs.