### PR TITLE
Drop netstandard1.x support

### DIFF
--- a/docs/HowTo/UpgradeFromV3.md
+++ b/docs/HowTo/UpgradeFromV3.md
@@ -10,7 +10,7 @@ MiniProfiler V4 has major breaking changes in layout compared to V3 due to needi
   * Fix: change `MiniProfiler.RenderIncludes()` to `MiniProfiler.Current.RenderIncludes()`
 * A `Name` field has been added to the SQL Server Profiler storage
   * Fix: Add a `nvarchar(200) null` field to your `MiniProfilers` table.
-* .NET 4.6.1+ (or `netstandard1.5`) are required (due to lack of the framework bits needed to really make async profiling work correctly).
+* .NET 4.6.1+ (or `netstandard2.0`) are required (due to lack of the framework bits needed to really make async profiling work correctly).
   * Fix: If you need .NET 4.6 and below, continue to use MiniProfiler V3.
 * `MiniProfiler.Step()` and `MiniProfiler.StepIf()` methods now return `Timing` (the same previous underlying type) instead of `IDisposable`.
   * Fix: this shouldn't require changes beyond a recompile, but adds functionality.

--- a/docs/NuGet.md
+++ b/docs/NuGet.md
@@ -12,7 +12,7 @@ MiniProfiler is split into the NuGet packages so you can easily select the bits 
   1. Reference the [`MiniProfiler.Providers.SqlServer`](https://www.nuget.org/packages/MiniProfiler.Providers.SqlServer) NuGet package.
   2. Use it via `MiniProfiler.Settings.Storage = new SqlServerStorage(ConnectionString);`
 
-#### NuGet Package list for ASP.NET Core (.NET Standard: `netstandard1.5`+)
+#### NuGet Package list for ASP.NET Core (.NET Standard: `netstandard2.0`+)
 * [MiniProfiler.AspNetCore](https://www.nuget.org/packages/MiniProfiler.AspNetCore/) - The core functionality (for .NET Standard applications)
 * [MiniProfiler.AspNetCore.Mvc](https://www.nuget.org/packages/MiniProfiler.AspNetCore.Mvc/) - ASP.NET Core MVC Integration 
 

--- a/src/MiniProfiler.AspNetCore.Mvc/MiniProfiler.AspNetCore.Mvc.csproj
+++ b/src/MiniProfiler.AspNetCore.Mvc/MiniProfiler.AspNetCore.Mvc.csproj
@@ -5,7 +5,7 @@
     <Description>Lightweight mini-profiler, designed for ASP.NET Core MVC (*not* System.Web) websites</Description>
     <Authors>Nick Craver</Authors>
     <PackageTags>ASP.NET Core;MVC;MVC Core;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.6;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.AspNetCore\MiniProfiler.AspNetCore.csproj" />
@@ -16,9 +16,5 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.2" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
+++ b/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <Description>Lightweight mini-profiler, designed for ASP.NET Core (not System.Web) websites</Description>
     <Authors>Nick Craver</Authors>
     <PackageTags>ASP.NET Core;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.5;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
@@ -20,12 +20,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.1.2" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.MongoDB/MiniProfiler.Providers.MongoDB.csproj
+++ b/src/MiniProfiler.Providers.MongoDB/MiniProfiler.Providers.MongoDB.csproj
@@ -5,15 +5,13 @@
     <Description>MiniProfiler: Profiler storage for MongoDB</Description>
     <Authors>Nick Craver, Roger Calaf</Authors>
     <PackageTags>NoSQL;MongoDB;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\miniprofiler.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>false</SignAssembly>
     <Company>Nick Craver, Roger Calaf</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
+    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -5,7 +5,7 @@
     <Description>MiniProfiler: Profiler storage for MySQL</Description>
     <Authors>Nick Craver, Bradley Grainger</Authors>
     <PackageTags>SQL;MySQL;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.RavenDB/MiniProfiler.Providers.RavenDB.csproj
+++ b/src/MiniProfiler.Providers.RavenDB/MiniProfiler.Providers.RavenDB.csproj
@@ -6,7 +6,7 @@
     <Authors>Marc Gravell, Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <PackageTags>Raven;RavenDB;$(PackageBaseTags)</PackageTags>
     <SignAssembly>false</SignAssembly>
-    <TargetFrameworks>net461;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
+++ b/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
@@ -5,7 +5,7 @@
     <Description>MiniProfiler: Profiler storage for Redis using StackExchange.Redis</Description>
     <Authors>Nick Craver, Joseph Daigle</Authors>
     <PackageTags>Redis;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
+++ b/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
@@ -5,7 +5,7 @@
     <Description>MiniProfiler: Profiler storage for SQL Server</Description>
     <Authors>Marc Gravell, Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <PackageTags>SQL;SQL Server;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
+++ b/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
@@ -5,16 +5,11 @@
     <Description>MiniProfiler: Profiler storage for SQLite</Description>
     <Authors>Nick Craver</Authors>
     <PackageTags>SQL;SQLite;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.ICloneable.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.ICloneable.cs
@@ -1,6 +1,4 @@
-﻿// Entity Framework 6 needs ICloneable
-#if !NETSTANDARD1_5
-using System;
+﻿using System;
 using System.Data.Common;
 
 namespace StackExchange.Profiling.Data
@@ -19,4 +17,3 @@ namespace StackExchange.Profiling.Data
         }
     }
 }
-#endif

--- a/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbCommand.cs
@@ -79,11 +79,7 @@ namespace StackExchange.Profiling.Data
                 return action;
             }
 
-            var prop = commandType
-#if NETSTANDARD1_5
-                .GetTypeInfo()
-#endif
-                .GetProperty("BindByName", BindingFlags.Public | BindingFlags.Instance);
+            var prop = commandType.GetProperty("BindByName", BindingFlags.Public | BindingFlags.Instance);
             action = null;
             ParameterInfo[] indexers;
             MethodInfo setter;

--- a/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbConnection.cs
@@ -190,7 +190,6 @@ namespace StackExchange.Profiling.Data
             OnStateChange(stateChangeEventArguments);
         }
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Gets a value indicating whether events can be raised.
         /// </summary>
@@ -222,6 +221,5 @@ namespace StackExchange.Profiling.Data
         /// <param name="restrictionValues">The restriction values.</param>
         /// <returns>The <see cref="DataTable"/>.</returns>
         public override DataTable GetSchema(string collectionName, string[] restrictionValues) => _connection.GetSchema(collectionName, restrictionValues);
-#endif
     }
 }

--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataAdapter.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataAdapter.cs
@@ -1,5 +1,4 @@
-﻿#if !NETSTANDARD1_5
-using System;
+﻿using System;
 using System.Data;
 using System.Data.Common;
 
@@ -256,4 +255,3 @@ namespace StackExchange.Profiling.Data
         }
     }
 }
-#endif

--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataReader.cs
@@ -226,7 +226,6 @@ namespace StackExchange.Profiling.Data
         /// <returns>true if there are more rows; otherwise, false.</returns>
         public override Task<bool> ReadAsync(CancellationToken cancellationToken) => WrappedReader.ReadAsync(cancellationToken);
 
-#if !NETSTANDARD1_5
         /// <summary>Closes the IDataReader Object.</summary>
         public override void Close()
         {
@@ -239,7 +238,6 @@ namespace StackExchange.Profiling.Data
         /// <summary>Returns a <see cref="DataTable"/> that describes the column metadata of the <see cref="IDataReader"/>.</summary>
         /// <returns>A <see cref="DataTable"/> that describes the column metadata.</returns>
         public override DataTable GetSchemaTable() => WrappedReader.GetSchemaTable();
-#endif
 
         /// <summary>Disposes the IDataReader Object.</summary>
         /// <param name="disposing">Whether to clear any managed resources.</param>
@@ -248,11 +246,6 @@ namespace StackExchange.Profiling.Data
             // reader can be null when we're not profiling, but we've inherited from ProfiledDbCommand and are returning a
             // an unwrapped reader from the base command
             WrappedReader?.Dispose();
-#if NETSTANDARD1_5
-            // Close isn't available in NETSTANDARD1_5, but Dispose *is*.
-            // Dispose should call close anyway, so we aren't calling ReaderFinish for other frameworks
-            _profiler?.ReaderFinish(this);
-#endif
             base.Dispose(disposing);
         }
     }

--- a/src/MiniProfiler.Shared/Data/ProfiledDbProviderFactory.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbProviderFactory.cs
@@ -1,9 +1,7 @@
 ﻿using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
-#if !NETSTANDARD1_5
 using System.Security;
 using System.Security.Permissions;
-#endif
 
 namespace StackExchange.Profiling.Data
 {
@@ -91,7 +89,6 @@ namespace StackExchange.Profiling.Data
         /// <param name="tail">The tail.</param>
         public void InitProfiledDbProviderFactory(DbProviderFactory tail) => _factory = tail;
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Specifies whether the specific <see cref="DbProviderFactory"/> supports the <see cref="DbDataSourceEnumerator"/> class.
         /// </summary>
@@ -123,7 +120,6 @@ namespace StackExchange.Profiling.Data
         /// <param name="state">One of the <see cref="PermissionState"/> values.</param>
         /// <returns>A <see cref="CodeAccessPermission"/> object for the specified <see cref="PermissionState"/>.</returns>
         public override CodeAccessPermission CreatePermission(PermissionState state) => _factory.CreatePermission(state);
-#endif
 #endif
     }
 }

--- a/src/MiniProfiler.Shared/Helpers/StackTraceSnippet.cs
+++ b/src/MiniProfiler.Shared/Helpers/StackTraceSnippet.cs
@@ -34,11 +34,7 @@ namespace StackExchange.Profiling.Helpers
                 return false;
             }
 
-#if !NETSTANDARD1_5
             var frames = new StackTrace().GetFrames();
-#else // The above works in netstandard2.0 via https://github.com/dotnet/corefx/pull/12527
-            StackFrame[] frames = null;
-#endif
 
             if (frames == null)
             {

--- a/src/MiniProfiler.Shared/Internal/IDataParameterExtensions.cs
+++ b/src/MiniProfiler.Shared/Internal/IDataParameterExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Data;
-#if NETSTANDARD1_5
-using System.Reflection;
-#endif
 
 namespace StackExchange.Profiling.Internal
 {
@@ -61,11 +58,7 @@ namespace StackExchange.Profiling.Internal
 
             // we want the integral value of an enum, not its string representation
             var rawType = rawValue.GetType();
-#if NETSTANDARD1_5
-            if (rawType.GetTypeInfo().IsEnum)
-#else
             if (rawType.IsEnum)
-#endif
             {
                 // use ChangeType, as we can't cast - http://msdn.microsoft.com/en-us/library/exx3b86w(v=vs.80).aspx
                 return Convert.ChangeType(rawValue, Enum.GetUnderlyingType(rawType)).ToString();

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -4,21 +4,16 @@
     <Title>MiniProfiler.Shared</Title>
     <Authors>Marc Gravell, Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <Description>You shouldn't reference this - MiniProfiler's shared library for all frameworks</Description>
-    <TargetFrameworks>net461;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.375" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />

--- a/src/MiniProfiler.Shared/MiniProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.cs
@@ -313,7 +313,6 @@ namespace StackExchange.Profiling
             }
         }
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Create a DEEP clone of this MiniProfiler.
         /// </summary>
@@ -332,7 +331,6 @@ namespace StackExchange.Profiling
                 return (MiniProfiler)serializer.ReadObject(ms);
             }
         }
-#endif
 
         internal Timing StepImpl(string name, decimal? minSaveMs = null, bool? includeChildrenWithMinSave = false)
         {

--- a/src/MiniProfiler.Shared/SqlFormatters/VerboseSqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/VerboseSqlServerFormatter.cs
@@ -1,4 +1,4 @@
-using StackExchange.Profiling.Internal;
+﻿using StackExchange.Profiling.Internal;
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
@@ -38,7 +38,7 @@ namespace StackExchange.Profiling.SqlFormatters
             {
                 buffer.Append("-- Command Type: ").Append(command.CommandType.ToString()).Append("\n");
                 buffer.Append("-- Database: ").Append(command.Connection.Database).Append("\n");
-#if !NETSTANDARD1_5
+
                 if (command.Transaction != null)
                 {
                     buffer.Append("-- Command Transaction Iso Level: ").Append(command.Transaction.IsolationLevel.ToString()).Append("\n");
@@ -48,7 +48,7 @@ namespace StackExchange.Profiling.SqlFormatters
                     // transactions issued by TransactionScope are not bound to the database command but exists globally
                     buffer.Append("-- Transaction Scope Iso Level: ").Append(System.Transactions.Transaction.Current.IsolationLevel.ToString()).Append("\n");
 				}
-#endif
+
                 buffer.Append("\n");
             }
 

--- a/tests/MiniProfiler.Tests.AspNetCore/MiniProfiler.Tests.AspNetCore.csproj
+++ b/tests/MiniProfiler.Tests.AspNetCore/MiniProfiler.Tests.AspNetCore.csproj
@@ -8,8 +8,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Tests\MiniProfiler.Tests.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.AspNetCore.Mvc\MiniProfiler.AspNetCore.Mvc.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Going forward, only support `netstandard2.x` and above, but retain the `net461` builds to minimize binding pain and related issues.

This also lessens the dependency tree in the provider libs that were relaying on the NETStandard library due to implicit references.

This is a "maybe" PR to illustrate the cruft and dependencies we could drop.