### PR TITLE
Cleanup: trim down references in .csproj

### DIFF
--- a/samples/Samples.AspNetCore3/Samples.AspNetCore3.csproj
+++ b/samples/Samples.AspNetCore3/Samples.AspNetCore3.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\..\src\MiniProfiler.EntityFrameworkCore\MiniProfiler.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.SqlServer\MiniProfiler.Providers.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.Sqlite\MiniProfiler.Providers.Sqlite.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0-preview9.19423.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0-rc1.19456.14" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
+++ b/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-preview9.19421.4" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-rc1.19456.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />

--- a/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
+++ b/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
@@ -1,19 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>MiniProfiler.EF6</AssemblyName>
+    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
     <Title>MiniProfiler for Entity Framework 6</Title>
     <Description>MiniProfiler: Integration for Entity Framework 6</Description>
     <Authors>Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <PackageTags>Entity Framework;Entity Framework 6;$(PackageBaseTags)</PackageTags>
     <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration">
-    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.EFC7/MiniProfiler.EFC7.csproj
+++ b/src/MiniProfiler.EFC7/MiniProfiler.EFC7.csproj
@@ -1,19 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>MiniProfiler.EFC7</AssemblyName>
+    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
     <Title>MiniProfiler for Entity Framework Classic 7</Title>
     <Description>MiniProfiler: Integration for Entity Framework Classic 7</Description>
     <Authors>Jarrod Dixon, Yaakov Ellis, Nick Craver, Jan Krynicky</Authors>
     <PackageTags>Entity Framework;Entity Framework Classic 7;$(PackageBaseTags)</PackageTags>
     <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration">
-    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Z.EntityFramework.Classic" Version="7.0.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.EntityFrameworkCore/MiniProfiler.EntityFrameworkCore.csproj
+++ b/src/MiniProfiler.EntityFrameworkCore/MiniProfiler.EntityFrameworkCore.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>MiniProfiler.EntityFrameworkCore</AssemblyName>
+    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
     <Title>MiniProfiler for Entity Framework Core</Title>
     <Description>MiniProfiler: Integration for Entity Framework Core</Description>
     <Authors>Nick Craver</Authors>
     <PackageTags>Entity Framework;Entity Framework Core;$(PackageBaseTags)</PackageTags>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration">
-    <RootNamespace>StackExchange.Profiling.Data</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Mvc5/MiniProfiler.Mvc5.csproj
+++ b/src/MiniProfiler.Mvc5/MiniProfiler.Mvc5.csproj
@@ -1,25 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>MiniProfiler.Mvc5</AssemblyName>
+    <RootNamespace>StackExchange.Profiling.Mvc</RootNamespace>
     <Title>MiniProfiler for MVC 5</Title>
     <Description>MiniProfiler: Extensions and helpers for ASP.NET MVC 5+ (non-.NET Core)</Description>
     <Authors>Marc Gravell, Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <PackageTags>ASP.NET;MVC;MVC 5;$(PackageBaseTags)</PackageTags>
     <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration">
-    <RootNamespace>StackExchange.Profiling.Mvc</RootNamespace>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler\MiniProfiler.csproj" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.MongoDB/MiniProfiler.Providers.MongoDB.csproj
+++ b/src/MiniProfiler.Providers.MongoDB/MiniProfiler.Providers.MongoDB.csproj
@@ -8,7 +8,6 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\miniprofiler.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>false</SignAssembly>
-    <Company>Nick Craver, Roger Calaf</Company>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.RavenDB/MiniProfiler.Providers.RavenDB.csproj
+++ b/src/MiniProfiler.Providers.RavenDB/MiniProfiler.Providers.RavenDB.csproj
@@ -12,9 +12,4 @@
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="RavenDB.Client" Version="3.5.4" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="System" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
+++ b/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
@@ -12,7 +12,4 @@
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
     <PackageReference Include="protobuf-net" Version="2.3.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="System" />
-  </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
+++ b/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
@@ -11,9 +11,4 @@
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-  </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.SqlServerCe/MiniProfiler.Providers.SqlServerCe.csproj
+++ b/src/MiniProfiler.Providers.SqlServerCe/MiniProfiler.Providers.SqlServerCe.csproj
@@ -11,8 +11,5 @@
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -24,15 +24,7 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ui\includes.less" />

--- a/src/MiniProfiler/MiniProfiler.csproj
+++ b/src/MiniProfiler/MiniProfiler.csproj
@@ -9,17 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.Linq" />
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removes all sorts of unused `.csproj` bits preparing for a 4.1.0 release.