### PR TITLE
Upgrade to 3.0 RTM packages and SDKs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ init:
   - SET PATH=%POSTGRES_PATH%\bin;%MYSQL_PATH%\bin;%PATH%
 
 install:
-  - choco install dotnetcore-sdk --version 3.0.100-preview9-014004
+  - choco install dotnetcore-sdk --version 3.0.100
   - nuget install redis-64 -excludeversion
   - redis-64\tools\redis-server.exe --service-install
   - redis-64\tools\redis-server.exe --service-start

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '3.0.100-preview9-014004'
+    version: '3.0.100'
 
 - task: PowerShell@2
   displayName: 'Build / Test / Create Packages'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "3.0.100",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100-preview9-014004"
+    "version": "3.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/samples/Samples.AspNetCore3/Samples.AspNetCore3.csproj
+++ b/samples/Samples.AspNetCore3/Samples.AspNetCore3.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\..\src\MiniProfiler.EntityFrameworkCore\MiniProfiler.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.SqlServer\MiniProfiler.Providers.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.Sqlite\MiniProfiler.Providers.Sqlite.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0-rc1.19456.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
+++ b/src/MiniProfiler.AspNetCore/MiniProfiler.AspNetCore.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-rc1.19456.4" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.1.0-preview.{height}",
+  "version": "4.1.0",
   "assemblyVersion": "4.0.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master


### PR DESCRIPTION
This bumps versioning off pre-release packages for the .NET Core 3.0 release today.