### PR TITLE
Builds: Move to traversal SDK for cleanup

### DIFF
--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.Build.Traversal/2.0.19">
+  <ItemGroup>
+    <ProjectReference Include="src\**\*.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(Packing) != 'true'">
+    <ProjectReference Include="samples\**\*.csproj" Exclude="samples\**\*Mvc5*.csproj" />
+    <ProjectReference Include="tests\**\*.csproj" />
+  </ItemGroup>
+</Project>

--- a/build.ps1
+++ b/build.ps1
@@ -11,53 +11,24 @@ Write-Host "  RunTests: $RunTests"
 Write-Host "  dotnet --version:" (dotnet --version)
 
 $packageOutputFolder = "$PSScriptRoot\.nupkgs"
-$projectsToBuild =
-    'MiniProfiler.Shared',
-    'MiniProfiler',
-    'MiniProfiler.EF6',
-    'MiniProfiler.EFC7',
-    'MiniProfiler.EntityFrameworkCore',
-    'MiniProfiler.Mvc5',
-    'MiniProfiler.AspNetCore',
-    'MiniProfiler.AspNetCore.Mvc',
-    'MiniProfiler.Providers.MongoDB',
-    'MiniProfiler.Providers.MySql',
-    'MiniProfiler.Providers.PostgreSql',
-    'MiniProfiler.Providers.Redis',
-    'MiniProfiler.Providers.Sqlite',
-    'MiniProfiler.Providers.SqlServer',
-    'MiniProfiler.Providers.SqlServerCe'
-
-$testsToRun =
-    'MiniProfiler.Tests',
-    'MiniProfiler.Tests.AspNet',
-    'MiniProfiler.Tests.AspNetCore'
 
 if ($PullRequestNumber) {
     Write-Host "Building for a pull request (#$PullRequestNumber), skipping packaging." -ForegroundColor Yellow
     $CreatePackages = $false
 }
 
-Write-Host "Building solution..." -ForegroundColor "Magenta"
-dotnet restore ".\MiniProfiler.sln" /p:CI=true
-dotnet build ".\MiniProfiler.sln" -c Release /p:CI=true
+Write-Host "Building all projects (Build.csproj traversal)..." -ForegroundColor "Magenta"
+dotnet build ".\Build.csproj" -c Release /p:CI=true
 Write-Host "Done building." -ForegroundColor "Green"
 
 if ($RunTests) {
-    foreach ($project in $testsToRun) {
-        Write-Host "Running tests: $project (all frameworks)" -ForegroundColor "Magenta"
-        Push-Location ".\tests\$project"
-
-        dotnet test -c Release --no-build --logger trx
-        if ($LastExitCode -ne 0) {
-            Write-Host "Error with tests, aborting build." -Foreground "Red"
-            Pop-Location
-            Exit 1
-        }
-
-        Write-Host "Tests passed!" -ForegroundColor "Green"
-	    Pop-Location
+    Write-Host "Running tests: Build.csproj traversal (all frameworks)" -ForegroundColor "Magenta"
+    dotnet test ".\Build.csproj" -c Release --no-build --logger trx
+    if ($LastExitCode -ne 0) {
+        Write-Host "Error with tests, aborting build." -Foreground "Red"
+        Exit 1
     }
+    Write-Host "Tests passed!" -ForegroundColor "Green"
 }
 
 if ($CreatePackages) {
@@ -67,12 +38,7 @@ if ($CreatePackages) {
     Write-Host "done." -ForegroundColor "Green"
 
     Write-Host "Building all packages" -ForegroundColor "Green"
-
-    foreach ($project in $projectsToBuild) {
-        Write-Host "Packing $project (dotnet pack)..." -ForegroundColor "Magenta"
-        dotnet pack ".\src\$project\$project.csproj" --no-build -c Release /p:PackageOutputPath=$packageOutputFolder /p:NoPackageAnalysis=true /p:CI=true
-        Write-Host ""
-    }
+    dotnet pack ".\Build.csproj" --no-build -c Release /p:Packing=true /p:PackageOutputPath=$packageOutputFolder /p:CI=true
 }
 
 Write-Host "Done."


### PR DESCRIPTION
This side-steps build errors with Samples (excluding Mvc5) and builds packages much faster in one pass. Yeah baby!

This is using Traversal from https://github.com/microsoft/MSBuildSdks - attempted long ago with broken edge cases but looks good now!