### PR TITLE
Open the connection once

### DIFF
--- a/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
+++ b/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
@@ -56,6 +56,7 @@ VALUES(@Id, @MiniProfilerId, @Name, @Start, @Duration)");
         {
             using (var conn = GetConnection())
             {
+                conn.Open();
                 conn.Execute(SaveSql, new
                 {
                     profiler.Id,
@@ -119,6 +120,7 @@ VALUES(@Id, @MiniProfilerId, @Name, @Start, @Duration)");
         {
             using (var conn = GetConnection())
             {
+                await conn.OpenAsync().ConfigureAwait(false);
                 await conn.ExecuteAsync(SaveSql, new
                 {
                     profiler.Id,

--- a/src/MiniProfiler.Providers.PostgreSql/PostgreSqlStorage.cs
+++ b/src/MiniProfiler.Providers.PostgreSql/PostgreSqlStorage.cs
@@ -60,6 +60,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                conn.Open();
                 conn.Execute(SaveSql, new
                 {
                     profiler.Id,
@@ -123,6 +124,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                await conn.OpenAsync().ConfigureAwait(false);
                 await conn.ExecuteAsync(SaveSql, new
                 {
                     profiler.Id,

--- a/src/MiniProfiler.Providers.SqlServer/SqlServerStorage.cs
+++ b/src/MiniProfiler.Providers.SqlServer/SqlServerStorage.cs
@@ -60,6 +60,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                conn.Open();
                 conn.Execute(SaveSql, new
                 {
                     profiler.Id,
@@ -123,6 +124,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                await conn.OpenAsync().ConfigureAwait(false);
                 await conn.ExecuteAsync(SaveSql, new
                 {
                     profiler.Id,

--- a/src/MiniProfiler.Providers.Sqlite/SqliteStorage.cs
+++ b/src/MiniProfiler.Providers.Sqlite/SqliteStorage.cs
@@ -60,6 +60,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                conn.Open();
                 conn.Execute(SaveSql, new
                 {
                     Id = profiler.Id.ToString(),
@@ -123,6 +124,7 @@ WHERE NOT EXISTS (SELECT 1 FROM {MiniProfilerClientTimingsTable} WHERE Id = @Id)
         {
             using (var conn = GetConnection())
             {
+                await conn.OpenAsync().ConfigureAwait(false);
                 await conn.ExecuteAsync(SaveSql, new
                 {
                     Id = profiler.Id.ToString(),


### PR DESCRIPTION
If the connection isn't already open, each call to `Execute(Async)` will open and close it, which is less efficient than opening it once and reusing the open connection.