### PR TITLE
Update MySqlConnector to 0.60.1

### DIFF
--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
-    <PackageReference Include="MySqlConnector" Version="0.30.0" />
+    <PackageReference Include="MySqlConnector" Version="0.60.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
MySqlConnector 0.30.0 is quite old; it seems like it would be best to use the latest version, which has the latest bug fixes and performance enhancements.

(MySqlConnector 0.30.0 is the oldest strong-named version, so if you want to rely on the oldest possible version that is compatible with anything your users want to upgrade to, then I understand if you want to close this PR. I just think it would be best to install the latest good version by default.)