### PR TITLE
Merge pull request #436 from duncansmart/MiniProfiler.EF6-netstandard2.1

### DIFF
--- a/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
+++ b/src/MiniProfiler.EF6/MiniProfiler.EF6.csproj
@@ -6,10 +6,10 @@
     <Description>MiniProfiler: Integration for Entity Framework 6</Description>
     <Authors>Jarrod Dixon, Yaakov Ellis, Nick Craver</Authors>
     <PackageTags>Entity Framework;Entity Framework 6;$(PackageBaseTags)</PackageTags>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
With EntityFramework 6.3 (non-Core) going netstandard2.1 means we can use it in .NET Core projects. EF 6.3 also fixes a bunch of bugs that have affected users of MiniProfiler in the past, e.g. #243, #345 and #380