### PR TITLE
Update StackExchange.Redis to latest

### DIFF
--- a/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
+++ b/src/MiniProfiler.Providers.Redis/MiniProfiler.Providers.Redis.csproj
@@ -8,8 +8,8 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
     <PackageReference Include="protobuf-net" Version="2.3.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
StackExchange.Redis no longer supports the old "Strongname" library that the dotnet MiniProfiler uses. The latest StackExchange.Redis is now the strongly named version by default. All updates since v2 are now only being applied to the base lib, StackExchange.Redis.

You may have reasons for not upgrading the Redis lib, but I wanted to propose an update. In particular, StackExchange.Redis.StrongName has been deprecated and is no longer receiving updates. The latest StackExchange.Redis is now strongly named by default. There are other changes that come along with the v2.x update that may affect your decision as well. Release notes are linked. v2.0.495 forward.

In particular, the v2 update includes this warning (emphasis mine):
`HARD BREAK: the package identity has changed; instead of StackExchange.Redis (not strong-named) and StackExchange.Redis.StrongName (strong-named), we are now only releasing StackExchange.Redis (strong-named). **This is a binary breaking change that requires consumers to be re-compiled**; it cannot be applied via binding-redirects`

https://stackexchange.github.io/StackExchange.Redis/ReleaseNotes.html