### PR TITLE
Add a nonce option and Render testing

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -94,7 +94,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
 ```html
 <mini-profiler />
 ```
-<sub>Note: `<mini-profiler>` has many options like `max-traces`, `position`, etc. [You can find them in code here](https://github.com/MiniProfiler/dotnet/blob/master/src/MiniProfiler.AspNetCore.Mvc/MiniProfilerScriptTagHelper.cs).</sub>
+<sub>Note: `<mini-profiler>` has many options like `max-traces`, `position`, `color-scheme`, `nonce`, etc. [You can find them in code here](https://github.com/MiniProfiler/dotnet/blob/master/src/MiniProfiler.AspNetCore.Mvc/MiniProfilerScriptTagHelper.cs).</sub>
 <sub>Note #2: The above tag helper registration may go away in future versions of ASP.NET Core, they're working on smoother alternatives here.</sub>
 
 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -5,6 +5,18 @@ layout: "default"
 ### Release Notes
 This page tracks major changes included in any update starting with version 4.0.0.3
 
+#### Version 4.2.0 (In preview)
+- Added `<script nonce="..." />` to rendering for CSP support ([#465](https://github.com/MiniProfiler/dotnet/pull/465))
+- Added dark and "auto" (system preference decides) color themes, total is "Light", "Dark", and "Auto" ([#451](https://github.com/MiniProfiler/dotnet/pull/451))
+  - Generally moves to CSS 3 variables, for easier custom themes as well.
+- Added `SqlServerFormatter.IncludeParameterValues` for excluding actual values in output if desired ([#463](https://github.com/MiniProfiler/dotnet/pull/463))
+- Fix for ['i.Started.toUTCString is not a function'](https://github.com/MiniProfiler/dotnet/pull/462) when global serializer options are changed.
+- Removed jQuery (built-in) dependency ([#442](https://github.com/MiniProfiler/dotnet/pull/442))
+  - Drops IE 11 support
+- Fix for missing `IMemoryCache` depending on config ([#440](https://github.com/MiniProfiler/dotnet/pull/440))
+- Updates `MySqlConnector` to 0.60.1 for misc fixes ([#432](https://github.com/MiniProfiler/dotnet/pull/432)) (thanks [@bgrainger](https://github.com/bgrainger)!)
+
+
 #### Version 4.1.0
 - ASP.NET Core 3.0 support ([MiniProfiler.AspNetCore](https://www.nuget.org/packages/MiniProfiler.AspNetCore/) and [MiniProfiler.AspNetCore.Mvc](https://www.nuget.org/packages/MiniProfiler.AspNetCore.Mvc/) packages, now with a `netcoreapp3.0` build)
 - Error support via `CustomTiming.Errored = true`, this will turn the UI red to raise error awareness ([#418](https://github.com/MiniProfiler/dotnet/pull/418) & [#420](https://github.com/MiniProfiler/dotnet/pull/420))

--- a/samples/Samples.AspNetCore3/Views/Shared/_Layout.cshtml
+++ b/samples/Samples.AspNetCore3/Views/Shared/_Layout.cshtml
@@ -46,7 +46,7 @@
     @RenderSection("scripts", required: false)
 
     @* Simple options are exposed...or make a full options class for customizing. *@
-    <mini-profiler position="@RenderPosition.Right" max-traces="5" color-scheme="ColorScheme.Auto" />
+    <mini-profiler position="@RenderPosition.Right" max-traces="5" color-scheme="ColorScheme.Auto" nonce="45" />
     @*<mini-profiler options="new RenderOptions { Position = RenderPosition.Right, MaxTracesToShow = 5, ColorScheme = ColorScheme.Auto }" />*@
 </body>
 </html>

--- a/src/MiniProfiler.AspNetCore.Mvc/MiniProfilerScriptTagHelper.cs
+++ b/src/MiniProfiler.AspNetCore.Mvc/MiniProfilerScriptTagHelper.cs
@@ -60,6 +60,12 @@ namespace StackExchange.Profiling
         public ColorScheme? ColorScheme { get; set; }
 
         /// <summary>
+        /// The JavaScript nonce (if any) to use on this script tag render.
+        /// </summary>
+        [HtmlAttributeName("nonce")]
+        public string Nonce { get; set; }
+
+        /// <summary>
         /// The options to use when rendering this MiniProfiler.
         /// Note: overrides all other options.
         /// </summary>
@@ -77,6 +83,7 @@ namespace StackExchange.Profiling
             if (ShowControls.HasValue) options.ShowControls = ShowControls;
             if (StartHidden.HasValue) options.StartHidden = StartHidden;
             if (ColorScheme.HasValue) options.ColorScheme = ColorScheme;
+            if (Nonce.HasValue()) options.Nonce = Nonce;
 
             return options;
         }

--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -84,7 +84,7 @@ namespace StackExchange.Profiling.Internal
             }
             if (renderOptions?.Nonce.HasValue() ?? false)
             {
-                sb.Append(" nonce=\"").Append(renderOptions.Nonce).Append("\"");
+                sb.Append(" nonce=\"").Append(System.Web.HttpUtility.HtmlAttributeEncode(renderOptions.Nonce)).Append("\"");
             }
 
             sb.Append(" data-max-traces=\"");

--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -28,7 +28,7 @@ namespace StackExchange.Profiling.Internal
             var sb = StringBuilderCache.Get();
             var options = profiler.Options;
 
-            sb.Append("<script async=\"async\" id=\"mini-profiler\" src=\"");
+            sb.Append("<script async id=\"mini-profiler\" src=\"");
             sb.Append(path);
             sb.Append("includes.min.js?v=");
             sb.Append(options.VersionHash);
@@ -81,6 +81,10 @@ namespace StackExchange.Profiling.Internal
             if (renderOptions?.StartHidden ?? options.PopupStartHidden)
             {
                 sb.Append(" data-start-hidden=\"true\"");
+            }
+            if (renderOptions?.Nonce.HasValue() ?? false)
+            {
+                sb.Append(" nonce=\"").Append(renderOptions.Nonce).Append("\"");
             }
 
             sb.Append(" data-max-traces=\"");

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ui\includes.min.css" DependentUpon="includes.css" />

--- a/src/MiniProfiler.Shared/RenderOptions.cs
+++ b/src/MiniProfiler.Shared/RenderOptions.cs
@@ -60,5 +60,11 @@ namespace StackExchange.Profiling
         /// Defaults to <see cref="MiniProfilerBaseOptions.ColorScheme"/>.
         /// </summary>
         public ColorScheme? ColorScheme { get; set; }
+
+        /// <summary>
+        /// A one-time-use nonce to render in the script tag.
+        /// </summary>
+        /// <remarks>https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script</remarks>
+        public string Nonce { get; set; }
     }
 }

--- a/tests/MiniProfiler.Tests/RenderTests.cs
+++ b/tests/MiniProfiler.Tests/RenderTests.cs
@@ -104,5 +104,20 @@ namespace StackExchange.Profiling.Tests
             result = Render.Includes(profiler, "/", true, renderOptions);
             Assert.Contains($@"nonce=""{nonce}""", result);
         }
+
+        [Theory]
+        [InlineData("foo", @"nonce=""foo""")]
+        [InlineData("foo!@#$%", @"nonce=""foo!@#$%""")]
+        [InlineData("e31df82b-5102-4134-af97-f29bf724bedd", @"nonce=""e31df82b-5102-4134-af97-f29bf724bedd""")]
+        [InlineData("f\"oo", @"nonce=""f&quot;oo""")]
+        [InlineData("󆲢L軾󯮃򮬛ŝ󅫤򄷌򆰃񟕺􆷀;鮡ƾ󤕵ԁf\'\"&23", @"nonce=""󆲢L軾󯮃򮬛ŝ󅫤򄷌򆰃񟕺􆷀;鮡ƾ󤕵ԁf&#39;&quot;&amp;23""")]
+        public void NonceEncoding(string nonce, string expected)
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions() { Nonce = nonce };
+
+            var result = Render.Includes(profiler, "/", true, renderOptions);
+            Assert.Contains(expected, result);
+        }
     }
 }

--- a/tests/MiniProfiler.Tests/RenderTests.cs
+++ b/tests/MiniProfiler.Tests/RenderTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using StackExchange.Profiling.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Profiling.Tests
+{
+    public class RenderTests : BaseTest
+    {
+        public RenderTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void DefaultRender()
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions();
+            var result = Render.Includes(profiler, "/", true, renderOptions, new List<Guid>() { profiler.Id });
+            Output.WriteLine("Result: " + result);
+
+            Assert.NotNull(result);
+            Assert.Contains("id=\"mini-profiler\"", result);
+
+            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Left"""" data-scheme=""Light"" data-authorized=""true"" data-max-traces=""15"" data-toggle-shortcut=""Alt+P"" data-trivial-milliseconds=""2.0"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void OptionsSet()
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions()
+            {
+                ColorScheme = ColorScheme.Auto,
+                MaxTracesToShow = 12,
+                Nonce = "myNonce",
+                PopupToggleKeyboardShortcut = "Alt+Q",
+                Position = RenderPosition.Right,
+                ShowControls = true,
+                ShowTimeWithChildren = true,
+                ShowTrivial = true,
+                StartHidden = true,
+                TrivialDurationThresholdMilliseconds = 23
+            };
+            var result = Render.Includes(profiler, "/", true, renderOptions, new List<Guid>() { profiler.Id });
+            Output.WriteLine("Result: " + result);
+
+            Assert.NotNull(result);
+            Assert.Contains("id=\"mini-profiler\"", result);
+
+            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Right"""" data-scheme=""Auto"" data-authorized=""true"" data-trivial=""true"" data-children=""true"" data-controls=""true"" data-start-hidden=""true"" nonce=""myNonce"" data-max-traces=""12"" data-toggle-shortcut=""Alt+Q"" data-trivial-milliseconds=""23"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, @"data-scheme=""Light""")]
+        [InlineData(ColorScheme.Auto, @"data-scheme=""Auto""")]
+        [InlineData(ColorScheme.Dark, @"data-scheme=""Dark""")]
+        [InlineData(ColorScheme.Light, @"data-scheme=""Light""")]
+        public void ColorSchemes(ColorScheme? scheme, string expected)
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions() { ColorScheme = scheme };
+
+            var result = Render.Includes(profiler, " / ", true, renderOptions);
+            Output.WriteLine("Result: " + result);
+
+            Assert.NotNull(result);
+            Assert.Contains(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, @"data-position=""Left""")]
+        [InlineData(RenderPosition.BottomLeft, @"data-position=""BottomLeft""")]
+        [InlineData(RenderPosition.BottomRight, @"data-position=""BottomRight""")]
+        [InlineData(RenderPosition.Left, @"data-position=""Left""")]
+        [InlineData(RenderPosition.Right, @"data-position=""Right""")]
+        public void Positions(RenderPosition? position, string expected)
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions() { Position = position };
+
+            var result = Render.Includes(profiler, " / ", true, renderOptions);
+            Output.WriteLine("Result: " + result);
+
+            Assert.NotNull(result);
+            Assert.Contains(expected, result);
+        }
+
+        [Fact]
+        public void Nonce()
+        {
+            var profiler = GetBasicProfiler();
+            var renderOptions = new RenderOptions();
+
+            // Default
+            var result = Render.Includes(profiler, "/", true, renderOptions);
+            Output.WriteLine("Result: " + result);
+            Assert.DoesNotContain("nonce", result);
+
+            // With nonce
+            var nonce = Guid.NewGuid().ToString();
+            renderOptions.Nonce = nonce;
+            result = Render.Includes(profiler, "/", true, renderOptions);
+            Assert.Contains($@"nonce=""{nonce}""", result);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #393, allows passing a nonce through the new `RenderOptions` API added in #451.

Also a minor optimization for async...we don't need that attribute value for any browser that'll support us today.