### PR TITLE
Shuffle DiagnosticListener to prevent double init

### DIFF
--- a/src/MiniProfiler.AspNetCore.Mvc/MvcExtensions.cs
+++ b/src/MiniProfiler.AspNetCore.Mvc/MvcExtensions.cs
@@ -18,11 +18,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds MiniProfiler timings for actions and views.
         /// </summary>
         /// <param name="services">The services collection to configure.</param>
-        /// <param name="configureOptions">An Action{MiniProfilerOptions} to configure options for MiniProfiler.</param>
+        /// <param name="configureOptions">An <see cref="Action{MiniProfilerOptions}"/> to configure options for MiniProfiler.</param>
         public static IMiniProfilerBuilder AddMiniProfiler(this IServiceCollection services, Action<MiniProfilerOptions> configureOptions = null)
         {
             services.AddMemoryCache(); // Unconditionally register an IMemoryCache since it's the most common and default case
             services.AddSingleton<IConfigureOptions<MiniProfilerOptions>, MiniProfilerOptionsDefaults>();
+            services.AddSingleton<DiagnosticInitializer>(); // For any IMiniProfilerDiagnosticListener registration
             if (configureOptions != null)
             {
                 services.Configure(configureOptions);

--- a/src/MiniProfiler.AspNetCore/MiniProfilerBuilderExtensions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerBuilderExtensions.cs
@@ -20,9 +20,8 @@ namespace Microsoft.AspNetCore.Builder
             _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             // Register all IMiniProfilerDiagnosticListeners that were registered, e.g. EntityFramework
-            var listeners = builder.ApplicationServices.GetServices<IMiniProfilerDiagnosticListener>();
-            var initializer = new DiagnosticInitializer(listeners);
-            initializer.Start();
+            // Note: this is a no-op after the first pass, e.g. for middleware branching support
+            builder.ApplicationServices.GetService<DiagnosticInitializer>()?.Start();
 
             return builder.UseMiddleware<MiniProfilerMiddleware>();
         }

--- a/src/MiniProfiler.Shared/DiagnosticInitializer.cs
+++ b/src/MiniProfiler.Shared/DiagnosticInitializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace StackExchange.Profiling.Internal
 {
@@ -11,6 +12,7 @@ namespace StackExchange.Profiling.Internal
     {
         private readonly List<IDisposable> _subscriptions = new List<IDisposable>();
         private readonly IEnumerable<IMiniProfilerDiagnosticListener> _diagnosticListeners;
+        private bool _initialized = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticInitializer"/> class.
@@ -26,7 +28,11 @@ namespace StackExchange.Profiling.Internal
         /// </summary>
         public void Start()
         {
-            DiagnosticListener.AllListeners.Subscribe(this);
+            if (!_initialized)
+            {
+                DiagnosticListener.AllListeners.Subscribe(this);
+                _initialized = true;
+            }
         }
 
         void IObserver<DiagnosticListener>.OnNext(DiagnosticListener value)

--- a/src/MiniProfiler.Shared/DiagnosticInitializer.cs
+++ b/src/MiniProfiler.Shared/DiagnosticInitializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 
 namespace StackExchange.Profiling.Internal
 {


### PR DESCRIPTION
Proposed fix for #469, this follows the intended pattern a bit closer and also makes `DiagnosticListener` accessible.

cc @haacked