### PR TITLE
Don't drop `Take` query instruction on the floor

### DIFF
--- a/src/MiniProfiler.Providers.RavenDB/RavenDbStorage.cs
+++ b/src/MiniProfiler.Providers.RavenDB/RavenDbStorage.cs
@@ -95,7 +95,7 @@ namespace StackExchange.Profiling.Storage
                 query = query.Where(x => x.Started <= finish.Value);
             }
 
-            query.Take(maxResults);
+            query = query.Take(maxResults);
 
             query = orderBy == ListResultsOrder.Descending
                 ? query.OrderByDescending(x => x.Started)
@@ -232,7 +232,7 @@ namespace StackExchange.Profiling.Storage
                 query = query.Where(x => x.Started <= finish.Value);
             }
 
-            query.Take(maxResults);
+            query = query.Take(maxResults);
 
             query = orderBy == ListResultsOrder.Descending
                 ? query.OrderByDescending(x => x.Started)


### PR DESCRIPTION
This looked like a bug to me, assuming that the query works similarly to a regular `IQueryable`/`IEnumerable`.