### PR TITLE
Use Razor Pages route value in MiniProfiler name

### DIFF
--- a/samples/Samples.AspNetCore3/Pages/RazorPagesSample.cshtml
+++ b/samples/Samples.AspNetCore3/Pages/RazorPagesSample.cshtml
@@ -1,0 +1,37 @@
+﻿@page
+
+@{
+    ViewData["Title"] = "Razor Pages Sample";
+}
+<div class="col-md-12">
+    <div class="page-header">
+        <h2>ASP.NET Core 3: Behold MiniProfiler in the top right!</h2>
+    </div>
+</div>
+<div class="row">
+    <partial name="Index.LeftPanel" />
+    <partial name="Index.RightPanel" />
+</div>
+@section scripts {
+    <script>
+        $(function () {
+            // these links should fire ajax requests, not do navigation
+            $('.ajax-requests a').click(function () {
+                var $clicked = $(this),
+                    $spinner = $('<span class="glyphicon glyphicon-refresh spinning" title="Working..."></span>').appendTo($clicked.parent()),
+                    $results = $('.ajax-results');
+
+                $.ajax({
+                    type: 'GET',
+                    url: this.href,
+                    success: function (data) {
+                        $('<p class="ajax-result">').append(data).appendTo($results);
+                    },
+                    error: function () { $results.append('<p>ERROR!</p>'); },
+                    complete: function () { $spinner.remove(); }
+                });
+                return false;
+            });
+        });
+    </script>
+}

--- a/samples/Samples.AspNetCore3/Pages/RazorPagesSample.cshtml
+++ b/samples/Samples.AspNetCore3/Pages/RazorPagesSample.cshtml
@@ -5,7 +5,7 @@
 }
 <div class="col-md-12">
     <div class="page-header">
-        <h2>ASP.NET Core 3: Behold MiniProfiler in the top right!</h2>
+        <h2>ASP.NET Core 3: Behold MiniProfiler in the top right (Razor Pages Version)!</h2>
     </div>
 </div>
 <div class="row">

--- a/samples/Samples.AspNetCore3/Pages/_ViewImports.cshtml
+++ b/samples/Samples.AspNetCore3/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using Samples.AspNetCore
+@namespace Samples.AspNetCore.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/samples/Samples.AspNetCore3/Pages/_ViewStart.cshtml
+++ b/samples/Samples.AspNetCore3/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/samples/Samples.AspNetCore3/Startup.cs
+++ b/samples/Samples.AspNetCore3/Startup.cs
@@ -12,6 +12,7 @@ namespace Samples.AspNetCore
     public class Startup
     {
         public static string SqliteConnectionString { get; } = "Data Source=Samples; Mode=Memory; Cache=Shared";
+
         private static readonly SqliteConnection TrapConnection = new SqliteConnection(SqliteConnectionString);
 
         public Startup(IWebHostEnvironment env)
@@ -118,7 +119,11 @@ namespace Samples.AspNetCore
             app.UseMiniProfiler()
                .UseStaticFiles()
                .UseRouting()
-               .UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+               .UseEndpoints(endpoints =>
+               {
+                   endpoints.MapDefaultControllerRoute();
+                   endpoints.MapRazorPages();
+               });
 
             var serviceScopeFactory = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>();
             using (var serviceScope = serviceScopeFactory.CreateScope())

--- a/samples/Samples.AspNetCore3/Views/Shared/_Layout.cshtml
+++ b/samples/Samples.AspNetCore3/Views/Shared/_Layout.cshtml
@@ -25,6 +25,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
+                    <li><a href="/RazorPagesSample">Razor Pages</a></li>
                 </ul>
             </div>
         </div>

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -146,16 +146,13 @@ namespace StackExchange.Profiling
                         .ToStringRecycle();
 
                 var routeData = context.GetRouteData();
-                if (routeData != null)
+                if (routeData?.Values["controller"] != null)
                 {
-                    if (routeData.Values["page"] != null)
-                    {
-                        profiler.Name = routeData.Values["page"].ToString();
-                    }
-                    else
-                    {
-                        profiler.Name = routeData.Values["controller"] + "/" + routeData.Values["action"];
-                    }
+                    profiler.Name = routeData.Values["controller"] + "/" + routeData.Values["action"];
+                }
+                else if (routeData?.Values["page"] != null)
+                {
+                    profiler.Name = routeData.Values["page"].ToString();
                 }
                 else
                 {

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -148,7 +148,14 @@ namespace StackExchange.Profiling
                 var routeData = context.GetRouteData();
                 if (routeData != null)
                 {
-                    profiler.Name = routeData.Values["controller"] + "/" + routeData.Values["action"];
+                    if (routeData.Values["page"] != null)
+                    {
+                        profiler.Name = routeData.Values["page"].ToString();
+                    }
+                    else
+                    {
+                        profiler.Name = routeData.Values["controller"] + "/" + routeData.Values["action"];
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
If you are using Razor Pages instead of controllers and views MiniProfiler shows all result names in the results list as `/`.  This is because `routeData.Values["controller"]` and `routeData.Values["action"]` are null.  

This change checks if `routeData.Values["pages"]` has a value and uses that for the MiniProfiler name if available.

I've also added a Razor Page to the Asp.Net Core 3 sample for testing