### PR TITLE
Remove double endquote in rendered HTML

### DIFF
--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -56,7 +56,6 @@ namespace StackExchange.Profiling.Internal
 
             sb.Append("\" data-position=\"");
             sb.Append((renderOptions?.Position ?? options.PopupRenderPosition).ToString());
-            sb.Append('"');
 
             sb.Append("\" data-scheme=\"");
             sb.Append((renderOptions?.ColorScheme ?? options.ColorScheme).ToString());

--- a/tests/MiniProfiler.Tests/RenderTests.cs
+++ b/tests/MiniProfiler.Tests/RenderTests.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Profiling.Tests
             Assert.NotNull(result);
             Assert.Contains("id=\"mini-profiler\"", result);
 
-            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Left"""" data-scheme=""Light"" data-authorized=""true"" data-max-traces=""15"" data-toggle-shortcut=""Alt+P"" data-trivial-milliseconds=""2.0"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
+            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Left"" data-scheme=""Light"" data-authorized=""true"" data-max-traces=""15"" data-toggle-shortcut=""Alt+P"" data-trivial-milliseconds=""2.0"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
             Assert.Equal(expected, result);
         }
 
@@ -48,7 +48,7 @@ namespace StackExchange.Profiling.Tests
             Assert.NotNull(result);
             Assert.Contains("id=\"mini-profiler\"", result);
 
-            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Right"""" data-scheme=""Auto"" data-authorized=""true"" data-trivial=""true"" data-children=""true"" data-controls=""true"" data-start-hidden=""true"" nonce=""myNonce"" data-max-traces=""12"" data-toggle-shortcut=""Alt+Q"" data-trivial-milliseconds=""23"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
+            var expected = $@"<script async id=""mini-profiler"" src=""/includes.min.js?v={Options.VersionHash}"" data-version=""{Options.VersionHash}"" data-path=""/"" data-current-id=""{profiler.Id}"" data-ids=""{profiler.Id}"" data-position=""Right"" data-scheme=""Auto"" data-authorized=""true"" data-trivial=""true"" data-children=""true"" data-controls=""true"" data-start-hidden=""true"" nonce=""myNonce"" data-max-traces=""12"" data-toggle-shortcut=""Alt+Q"" data-trivial-milliseconds=""23"" data-ignored-duplicate-execute-types=""Open,OpenAsync,Close,CloseAsync""></script>";
             Assert.Equal(expected, result);
         }
 


### PR DESCRIPTION
The latest release renders HTML with two endquotes for the data-position argument:
```html
   <script src="..." data-position="Left"" data-scheme="Light" <!-- other arguments -->></script> 
```