### PR TITLE
JS: Remember visibility via localStorage

### DIFF
--- a/samples/Samples.AspNetCore2/Samples.AspNetCore2.csproj
+++ b/samples/Samples.AspNetCore2/Samples.AspNetCore2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
+++ b/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Samples.Console</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -106,7 +106,7 @@ namespace StackExchange.Profiling
                 // Stop (and record)
                 await mp.StopAsync().ConfigureAwait(false);
 
-#if NETCOREAPP3_0 // TODO: Evaluate if this works after http/2 local support in preview 7, maybe backport to netcoreapp2.2
+#if NETCOREAPP3_0 // TODO: Evaluate if this works after http/2 local support in preview 7, maybe backport to netcoreapp2.1
                 if (appendServerTimingHeader && mp != null)
                 {
                     context.Response.AppendTrailer("Server-Timing", mp.GetServerTimingHeader());

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -315,8 +315,15 @@ namespace StackExchange.Profiling {
 
                         // fetch and render results
                         mp.fetchResults(mp.options.ids);
+                        
+                        let lsDisplayValue;
+                        try {
+                            lsDisplayValue = window.localStorage.getItem('MiniProfiler-Display');
+                        } catch(e) { }
 
-                        if (mp.options.startHidden) {
+                        if (lsDisplayValue) {
+                            mp.container.style.display = lsDisplayValue;
+                        } else if (mp.options.startHidden) {
                             mp.container.style.display = 'none';
                         }
 
@@ -1206,7 +1213,11 @@ namespace StackExchange.Profiling {
                             && e.shiftKey == modifiers.shift.wanted
                             && e.altKey == modifiers.alt.wanted) {
                             const results = document.querySelector<HTMLElement>('.mp-results');
-                            results.style.display = results.style.display == 'none' ? 'block' : 'none';
+                            const newValue = results.style.display == 'none' ? 'block' : 'none';
+                            results.style.display = newValue;
+                            try {
+                                window.localStorage.setItem('MiniProfiler-Display', newValue);
+                            } catch(e) { }
                         }
                     }, false);
                 }

--- a/tests/MiniProfiler.Tests.AspNetCore/MiniProfiler.Tests.AspNetCore.csproj
+++ b/tests/MiniProfiler.Tests.AspNetCore/MiniProfiler.Tests.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>MiniProfiler.Tests.AspNetCore</AssemblyName>
     <RootNamespace>StackExchange.Profiling.Tests</RootNamespace>
-    <TargetFrameworks>net461;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Tests\MiniProfiler.Tests.csproj" />

--- a/tests/MiniProfiler.Tests/MiniProfiler.Tests.csproj
+++ b/tests/MiniProfiler.Tests/MiniProfiler.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>MiniProfiler.Tests</AssemblyName>
     <RootNamespace>StackExchange.Profiling.Tests</RootNamespace>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MiniProfiler.Providers.MongoDB\MiniProfiler.Providers.MongoDB.csproj" />


### PR DESCRIPTION
We can go simple here because there is no security issue, it's just a CSS style we're storing. Basically we're just remember whether it's shown or hidden across page views - this take precedence over settings from the server for default visibility.

Note: I'm just `try`/`catch`ing around Mobile Safari's shenanigans since we are only seeing if this works and using it in _one_ case. The 99% case here should be smooth sailing, and in the case it doesn't work: there's nothing to do here.