### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />
     <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
-    <PackageReference Include="MySqlConnector" Version="0.60.2" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
+++ b/src/MiniProfiler.Providers.MySql/MySqlStorage.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using StackExchange.Profiling.Internal;
 
 namespace StackExchange.Profiling.Storage


### PR DESCRIPTION
MySqlConnector 1.0 introduces a breaking change by changing the namespace: https://github.com/mysql-net/MySqlConnector/issues/824

This updates the dependency and fixes the code.