### PR TITLE
Empty array instead of null when handling customtimings

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -519,7 +519,7 @@ namespace StackExchange.Profiling {
                     timing.HasCustomTimings = true;
                     result.HasCustomTimings = true;
                     for (const customType of Object.keys(timing.CustomTimings)) {
-                        const customTimings = timing.CustomTimings[customType];
+                        const customTimings = timing.CustomTimings[customType] || [] as ICustomTiming[];
                         const customStat = {
                             Duration: 0,
                             Count: 0,


### PR DESCRIPTION
Fixes the null reference error when customtiming object does not have any timings but the key exists:
https://twitter.com/andersaberg/status/1285660570608377856

Made the change in the browser, but I hope the TS syntax was correct.