### PR TITLE
Add check to use Endpoint.DisplayName over base url when naming profiler

### DIFF
--- a/samples/Samples.AspNetCore3/Startup.cs
+++ b/samples/Samples.AspNetCore3/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -119,13 +120,28 @@ namespace Samples.AspNetCore
                 app.UseExceptionHandler("/Home/Error");
             }
 
+            
             app.UseMiniProfiler()
                .UseStaticFiles()
                .UseRouting()
                .UseEndpoints(endpoints =>
                {
-                   endpoints.MapDefaultControllerRoute();
+                   endpoints.MapAreaControllerRoute("areaRoute", "MySpace",
+                       "MySpace/{controller=Home}/{action=Index}/{id?}");
+                   endpoints.MapControllerRoute("default_route","{controller=Home}/{action=Index}/{id?}");
+                  
                    endpoints.MapRazorPages();
+                   endpoints.MapGet("/named-endpoint", async httpContext =>
+                   {
+                       var endpointName = httpContext.GetEndpoint().DisplayName;
+                       await httpContext.Response.WriteAsync($"Content from an endpoint named {endpointName}");
+                   }).WithDisplayName("Named Endpoint");
+
+                   endpoints.MapGet("implicitly-named-endpoint", async httpContext =>
+                   {
+                       var endpointName = httpContext.GetEndpoint().DisplayName;
+                       await httpContext.Response.WriteAsync($"Content from an endpoint named {endpointName}");
+                   });
                });
 
             var serviceScopeFactory = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>();

--- a/samples/Samples.AspNetCore3/Views/Shared/Index.LeftPanel.cshtml
+++ b/samples/Samples.AspNetCore3/Views/Shared/Index.LeftPanel.cshtml
@@ -15,6 +15,8 @@
                 <li><a asp-controller="Test" asp-action="EntityFrameworkCore">Entity Framework Core</a></li>
                 <li><a asp-controller="Test" asp-action="Errored">Error test</a></li>
                 <li><a asp-area="MySpace" asp-controller="Area" asp-action="Simple">Area Route</a></li>
+                <li><a href="/named-endpoint">Named Endpoint</a></li>
+                <li><a href="/implicitly-named-endpoint">Implicitly Named Endpoint</a></li>
             </ul>
         </div>
     </div>

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -154,7 +154,13 @@ namespace StackExchange.Profiling
                 {
                     profiler.Name = routeData.Values["page"].ToString();
                 }
-                else
+#if NETCOREAPP3_0
+                else if (context.GetEndpoint() is Endpoint endPoint && endPoint.DisplayName.HasValue())
+                {
+                    profiler.Name = endPoint.DisplayName;
+                }    
+#endif
+               else
                 {
                     profiler.Name = url;
                     if (profiler.Name.Length > 50)


### PR DESCRIPTION
Enhancement requested in #514 

Two example routes added to Sample App for 3.0 to highlight explicit vs. implicit endpoint naming.

Also adds a fix in the sample project to correctly configure areas with endpoint routing that can be removed if needed. As is the area route link in the Sample resulted in a 404 for me.   