### PR TITLE
Fixes for casting exceptions when using SqliteStorage with local db

### DIFF
--- a/samples/Samples.AspNetCore2/Startup.cs
+++ b/samples/Samples.AspNetCore2/Startup.cs
@@ -122,7 +122,7 @@ namespace Samples.AspNetCore
                 dbContext.Database.EnsureCreated();
             }
             // For nesting test routes
-            new SqliteStorage(SqliteConnectionString).WithSchemaCreation();
+            new SqliteStorage(SqliteConnectionString);
         }
     }
 }

--- a/samples/Samples.AspNetCore3/Startup.cs
+++ b/samples/Samples.AspNetCore3/Startup.cs
@@ -151,7 +151,7 @@ namespace Samples.AspNetCore
                 dbContext.Database.EnsureCreated();
             }
             // For nesting test routes
-            new SqliteStorage(SqliteConnectionString).WithSchemaCreation();
+            new SqliteStorage(SqliteConnectionString);
         }
     }
 }


### PR DESCRIPTION
With SqliteStorage when using a local db file 

1. Added "IF NOT EXISTS" clause to create table script to prevent the exception when starting the project for the second time. 

2. Added decimal points to instances when missing to prevent Dapper mapping from throwing a cast exceptions

![image](https://user-images.githubusercontent.com/6900191/91833618-854f8300-ec79-11ea-83ba-3fc7b1a4eafa.png)

