### PR TITLE
Update AspDotNetCore.md to add Memory Cache

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -21,6 +21,9 @@ Install-Package MiniProfiler.AspNetCore.Mvc -IncludePrerelease
 public void ConfigureServices(IServiceCollection services)
 {
     // ...existing configuration...
+    
+    // Ensure Memory Cache is added for MiniProfiler to work
+    services.AddMemoryCache();
 
     // Note .AddMiniProfiler() returns a IMiniProfilerBuilder for easy intellisense
     services.AddMiniProfiler(options =>


### PR DESCRIPTION
Add required step to add services.AddMemoryCache() which is essential for MiniProfiler to work in .Net Core