### PR TITLE
Step Extension

### DIFF
--- a/samples/Samples.Mvc5.EFCore/Global.asax.cs
+++ b/samples/Samples.Mvc5.EFCore/Global.asax.cs
@@ -67,7 +67,7 @@ namespace Samples.Mvc5
                 profiler = MiniProfiler.StartNew();
             }
 
-            using (profiler.Step("Application_BeginRequest"))
+            using (profiler.Step(profiler.GetDefaultStepName()))
             {
                 // you can start profiling your code immediately
             }

--- a/samples/Samples.Mvc5.EFCore/Global.asax.cs
+++ b/samples/Samples.Mvc5.EFCore/Global.asax.cs
@@ -67,7 +67,7 @@ namespace Samples.Mvc5
                 profiler = MiniProfiler.StartNew();
             }
 
-            using (profiler.Step(profiler.GetDefaultStepName()))
+            using (profiler.Step())
             {
                 // you can start profiling your code immediately
             }

--- a/src/MiniProfiler.Shared/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.Shared/MiniProfilerExtensions.cs
@@ -39,7 +39,7 @@ namespace StackExchange.Profiling
         /// <param name="name">A descriptive name for the code that is encapsulated by the resulting Timing's lifetime.</param>
         /// <returns>the profile step</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Timing Step(this MiniProfiler profiler, string name) => profiler?.StepImpl(name);
+        public static Timing Step(this MiniProfiler profiler, [CallerMemberName] string name = null) => profiler?.StepImpl(name);
 
         /// <summary>
         /// Returns an <see cref="Timing"/> (<see cref="IDisposable"/>) that will time the code between its creation and disposal.

--- a/src/MiniProfiler.Shared/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.Shared/MiniProfilerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using StackExchange.Profiling.Internal;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
@@ -212,6 +213,43 @@ namespace StackExchange.Profiling
             }
 
             return text.ToStringRecycle();
+        }
+        
+        /// <summary>
+        /// Get the default method name.
+        /// </summary>
+        /// <param name="profiler">Should be empty.</param>
+        /// <param name="callerName">Should be empty.</param>
+        /// <param name="fileName">Should be empty.</param>
+        /// <returns></returns>
+        public static string GetDefaultStepName(this MiniProfiler profiler, [CallerMemberName] string callerName = null)
+        {
+            return callerName;
+        }
+        
+        /// <summary>
+        /// Get the default method name.
+        /// </summary>
+        /// <param name="profiler">Should be empty.</param>
+        /// <param name="callerName">Should be empty.</param>
+        /// <param name="fileName">Should be empty.</param>
+        /// <returns></returns>
+        public static string GetDefaultStepNameWithClassName(this MiniProfiler profiler, [CallerMemberName] string callerName = null, [CallerFilePath] string fileName = null)
+        {
+            return $"{Path.GetFileNameWithoutExtension(fileName)}.{callerName}";
+        }
+        
+        /// <summary>
+        /// Get the default method name.
+        /// </summary>
+        /// <param name="profiler">Should be empty.</param>
+        /// <param name="callerName">Should be empty.</param>
+        /// <param name="fileName">Should be empty.</param>
+        /// <param name="line">Should be empty.</param>
+        /// <returns></returns>
+        public static string GetDefaultStepNameWithLine(this MiniProfiler profiler, [CallerMemberName] string callerName = null, [CallerFilePath] string fileName = null, [CallerLineNumber] int line = 0)
+        {
+            return $"{Path.GetFileNameWithoutExtension(fileName)}.{callerName}:{line}";
         }
     }
 }


### PR DESCRIPTION
I started using the profiler in a WebAPI project and realized that it was very uncomfortable for me to write the name of a step with my hands.

So I propose an extension that will generate a step name.

``` cs
protected void SomeMethod()
{
    using (profiler.Step(profiler.GetDefaultStepName()))
    {
        // you can start profiling your code immediately
    }
}
//or
protected void SomeMethod()
{
    using (profiler.Step())
    {
        // you can start profiling your code immediately
    }
}
```


``` cs
string GetDefaultStepName(); 
string GetDefaultStepNameWithClassName();
string GetDefaultStepNameWithLine();
```
Only 3 methods which will generate type names:


``` cs
string GetDefaultStepName(); 
//SomeMethod
```
``` cs
string GetDefaultStepNameWithClassName();
// SomeController.SomeMethod
```

``` cs
string GetDefaultStepNameWithLine();
// SomeController.SomeMethod:59
```

and
``` cs
  using (profiler.Step())
// SomeMethod
```
