### PR TITLE
MongoDB: Allow custom collection names for profiling results

### DIFF
--- a/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
+++ b/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
@@ -19,7 +19,8 @@ namespace StackExchange.Profiling
         /// Returns a new <see cref="MongoDbStorage"/>. MongoDb connection string will default to "mongodb://localhost"
         /// </summary>
         /// <param name="connectionString">The MongoDB connection string.</param>
-        public MongoDbStorage(string connectionString)
+        /// <param name="collectionName">The collection name to use in the database.</param>
+        public MongoDbStorage(string connectionString, string collectionName = "profilers")
         {
             if (!BsonClassMap.IsClassMapRegistered(typeof(MiniProfiler)))
             {
@@ -32,7 +33,7 @@ namespace StackExchange.Profiling
             _client = new MongoClient(url);
             _collection = _client
                 .GetDatabase(databaseName)
-                .GetCollection<MiniProfiler>("profilers");
+                .GetCollection<MiniProfiler>(collectionName);
         }
 
         private static void BsonClassMapFields()

--- a/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
+++ b/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
@@ -19,8 +19,14 @@ namespace StackExchange.Profiling
         /// Returns a new <see cref="MongoDbStorage"/>. MongoDb connection string will default to "mongodb://localhost"
         /// </summary>
         /// <param name="connectionString">The MongoDB connection string.</param>
+        public MongoDbStorage(string connectionString) : this(connectionString, "profilers") { }
+
+        /// <summary>
+        /// Returns a new <see cref="MongoDbStorage"/>. MongoDb connection string will default to "mongodb://localhost"
+        /// </summary>
+        /// <param name="connectionString">The MongoDB connection string.</param>
         /// <param name="collectionName">The collection name to use in the database.</param>
-        public MongoDbStorage(string connectionString, string collectionName = "profilers")
+        public MongoDbStorage(string connectionString, string collectionName)
         {
             if (!BsonClassMap.IsClassMapRegistered(typeof(MiniProfiler)))
             {

--- a/tests/MiniProfiler.Tests/Storage/MongoDbStorageTests.cs
+++ b/tests/MiniProfiler.Tests/Storage/MongoDbStorageTests.cs
@@ -19,7 +19,11 @@ namespace StackExchange.Profiling.Tests.Storage
 
             try
             {
-                Storage = new MongoDbStorage(TestConfig.Current.MongoDbConnectionString).WithIndexCreation();
+                Storage = new MongoDbStorage(
+                    TestConfig.Current.MongoDbConnectionString,
+                    "MPTest" + TestId);
+                
+                Storage.WithIndexCreation();
                 Storage.GetUnviewedIds("");
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #542 

Part of me wanted to add a test to assert the optional collection name but with how the code is structured currently, it felt a little over the top.