### PR TITLE
Inline Formatter: Null values no longer appear as an empty string

### DIFF
--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -63,20 +63,23 @@ namespace StackExchange.Profiling.SqlFormatters
             var result = param.Value;
             var type = param.DbType ?? string.Empty;
 
-            switch (type.ToLower())
+            if (result != null)
             {
-                case "string":
-                case "datetime":
-                    result = string.Format("'{0}'", result);
-                    break;
-                case "boolean":
-                    result = result switch
-                    {
-                        "True" => "1",
-                        "False" => "0",
-                        _ => null,
-                    };
-                    break;
+                switch (type.ToLower())
+                {
+                    case "string":
+                    case "datetime":
+                        result = string.Format("'{0}'", result);
+                        break;
+                    case "boolean":
+                        result = result switch
+                        {
+                            "True" => "1",
+                            "False" => "0",
+                            _ => null,
+                        };
+                        break;
+                }
             }
 
             result ??= "null";

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -103,6 +103,20 @@ namespace StackExchange.Profiling.Tests
         }
 
         [Fact]
+        public void InlineParameterValuesDisplayNullForStrings()
+        {
+            var formatter = new InlineFormatter();
+            var parameters = new List<SqlTimingParameter>
+            {
+                new SqlTimingParameter() { DbType = "string", Name = "url", Value = "http://www.example.com?myid=1" },
+                new SqlTimingParameter() { DbType = "string", Name = "myid", Value = null }
+            };
+            const string command = "SELECT * FROM urls WHERE url = @url OR @myid IS NULL";
+            var formatted = formatter.FormatSql(command, parameters);
+            Assert.Equal("SELECT * FROM urls WHERE url = 'http://www.example.com?myid=1' OR null IS NULL", formatted);
+        }
+
+        [Fact]
         public void EnsureVerboseSqlServerFormatterOnlyAddsInformation()
         {
             const string text = "select 1";


### PR DESCRIPTION
Fixes #546

A `null` value passed to `string.Format("'{0}'", result)` returns an `''` and not `null`. To fix this, I skip the entire switch block on a `null` result, falling through to the `result ??= "null";` below it.