### PR TITLE
InlineFormatter: Optionally support spacing around commas

### DIFF
--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -5,6 +5,10 @@ layout: "default"
 ### Release Notes
 This page tracks major changes included in any update starting with version 4.0.0.3
 
+#### Unreleased
+- **New**:
+  - Added an option to control `SpacesAfterCommas` to `InlineSqlFormatter` and `SqlServerFormatter` ([#549](https://github.com/MiniProfiler/dotnet/pull/549) - thanks [Turnerj](https://github.com/Turnerj))
+
 #### Version 4.2.1
 - **New**:
   - Added RavenDB Storage provider ([#483](https://github.com/MiniProfiler/dotnet/pull/483) - thanks [@lillo42](https://github.com/lillo42)!)

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -11,25 +11,20 @@ namespace StackExchange.Profiling.SqlFormatters
     {
         private static readonly Regex CommandSpacing = new Regex(@",([^\s])", RegexOptions.Compiled);
         private static bool includeTypeInfo;
-        private static bool increaseReadability;
+
+        /// <summary>
+        /// Modifies the output query to increase readibility by adding spaces around crowded commas.
+        /// </summary>
+        public bool IncreaseReadability { get; set; } = true;
 
         /// <summary>
         /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
         /// in comments beside the replaced value
         /// </summary>
         /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
-        public InlineFormatter(bool includeTypeInfo = false) : this(true, includeTypeInfo) { }
-
-        /// <summary>
-        /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
-        /// in comments beside the replaced value
-        /// </summary>
-        /// <param name="increaseReadability">Modifies the output query to increase readibility by adding spaces around crowded commas.</param>
-        /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
-        public InlineFormatter(bool increaseReadability, bool includeTypeInfo = false)
+        public InlineFormatter(bool includeTypeInfo = false)
         {
             InlineFormatter.includeTypeInfo = includeTypeInfo;
-            InlineFormatter.increaseReadability = increaseReadability;
         }
 
         /// <summary>
@@ -45,7 +40,7 @@ namespace StackExchange.Profiling.SqlFormatters
                 return commandText;
             }
 
-            if (increaseReadability)
+            if (IncreaseReadability)
             {
                 commandText = CommandSpacing.Replace(commandText, ", $1");
             }

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -18,18 +18,18 @@ namespace StackExchange.Profiling.SqlFormatters
         /// in comments beside the replaced value
         /// </summary>
         /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
-        public InlineFormatter(bool includeTypeInfo = false) : this(includeTypeInfo, true) { }
+        public InlineFormatter(bool includeTypeInfo = false) : this(true, includeTypeInfo) { }
 
         /// <summary>
         /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info and whether to increase readibility.
         /// in comments beside the replaced value
         /// </summary>
-        /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
         /// <param name="increaseReadability">Modifies the output query to increase readibility by adding spaces around crowded commas.</param>
-        public InlineFormatter(bool includeTypeInfo = false, bool increaseReadability = true)
+        /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
+        public InlineFormatter(bool increaseReadability, bool includeTypeInfo = false)
         {
             InlineFormatter.includeTypeInfo = includeTypeInfo;
-            InlineFormatter.increaseReadability = true;
+            InlineFormatter.increaseReadability = increaseReadability;
         }
 
         /// <summary>

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Profiling.SqlFormatters
         public InlineFormatter(bool includeTypeInfo = false) : this(true, includeTypeInfo) { }
 
         /// <summary>
-        /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info and whether to increase readibility.
+        /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
         /// in comments beside the replaced value
         /// </summary>
         /// <param name="increaseReadability">Modifies the output query to increase readibility by adding spaces around crowded commas.</param>

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -13,9 +13,9 @@ namespace StackExchange.Profiling.SqlFormatters
         private static bool includeTypeInfo;
 
         /// <summary>
-        /// Modifies the output query to increase readibility by adding spaces around crowded commas.
+        /// Modifies the output query by adding spaces after commas.
         /// </summary>
-        public bool IncreaseReadability { get; set; } = true;
+        public bool SpaceAfterComma { get; set; } = true;
 
         /// <summary>
         /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
@@ -40,7 +40,7 @@ namespace StackExchange.Profiling.SqlFormatters
                 return commandText;
             }
 
-            if (IncreaseReadability)
+            if (SpaceAfterComma)
             {
                 commandText = CommandSpacing.Replace(commandText, ", $1");
             }

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -13,9 +13,9 @@ namespace StackExchange.Profiling.SqlFormatters
         private static bool includeTypeInfo;
 
         /// <summary>
-        /// Modifies the output query by adding spaces after commas.
+        /// Whether to modify the output query by adding spaces after commas.
         /// </summary>
-        public bool SpaceAfterComma { get; set; } = true;
+        public bool InsertSpacesAfterCommas { get; set; } = true;
 
         /// <summary>
         /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
@@ -40,7 +40,7 @@ namespace StackExchange.Profiling.SqlFormatters
                 return commandText;
             }
 
-            if (SpaceAfterComma)
+            if (InsertSpacesAfterCommas)
             {
                 commandText = CommandSpacing.Replace(commandText, ", $1");
             }

--- a/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/InlineFormatter.cs
@@ -9,16 +9,27 @@ namespace StackExchange.Profiling.SqlFormatters
     /// </summary>
     public class InlineFormatter : ISqlFormatter
     {
+        private static readonly Regex CommandSpacing = new Regex(@",([^\s])", RegexOptions.Compiled);
         private static bool includeTypeInfo;
+        private static bool increaseReadability;
 
         /// <summary>
         /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info 
         /// in comments beside the replaced value
         /// </summary>
         /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
-        public InlineFormatter(bool includeTypeInfo = false)
+        public InlineFormatter(bool includeTypeInfo = false) : this(includeTypeInfo, true) { }
+
+        /// <summary>
+        /// Creates a new <see cref="InlineFormatter"/>, optionally including the parameter type info and whether to increase readibility.
+        /// in comments beside the replaced value
+        /// </summary>
+        /// <param name="includeTypeInfo">Whether to include a comment after the value, indicating the type, e.g. <c>/* @myParam DbType.Int32 */</c></param>
+        /// <param name="increaseReadability">Modifies the output query to increase readibility by adding spaces around crowded commas.</param>
+        public InlineFormatter(bool includeTypeInfo = false, bool increaseReadability = true)
         {
             InlineFormatter.includeTypeInfo = includeTypeInfo;
+            InlineFormatter.increaseReadability = true;
         }
 
         /// <summary>
@@ -34,6 +45,11 @@ namespace StackExchange.Profiling.SqlFormatters
                 return commandText;
             }
 
+            if (increaseReadability)
+            {
+                commandText = CommandSpacing.Replace(commandText, ", $1");
+            }
+            
             var paramValuesByName = new Dictionary<string, string>(parameters.Count);
             foreach (var p in parameters)
             {

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlFormatterExtensions.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlFormatterExtensions.cs
@@ -35,7 +35,7 @@ namespace StackExchange.Profiling.SqlFormatters
         /// <param name="command">The <see cref="IDbCommand"/> being represented.</param>
         public static string GetFormattedSql(this ISqlFormatter sqlFormatter, IDbCommand command)
         {
-            var commandText = command.GetReadableCommand();
+            var commandText = command.CommandText;
             var parameters = command.GetParameters();
 
             return sqlFormatter.GetFormattedSql(commandText, parameters, command);

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace StackExchange.Profiling.SqlFormatters
 {
@@ -12,10 +13,17 @@ namespace StackExchange.Profiling.SqlFormatters
     /// </summary>
     public class SqlServerFormatter : ISqlFormatter
     {
+        private static readonly Regex CommandSpacing = new Regex(@",([^\s])", RegexOptions.Compiled);
+
         /// <summary>
         /// Whether to include parameter declarations in the formatted output.
         /// </summary>
         public bool IncludeParameterValues { get; set; } = true;
+
+        /// <summary>
+        /// Modifies the output query to increase readibility by adding spaces around crowded commas.
+        /// </summary>
+        public bool IncreaseReadability { get; set; } = true;
 
         /// <summary>
         /// Lookup a function for translating a parameter by parameter type
@@ -110,6 +118,11 @@ namespace StackExchange.Profiling.SqlFormatters
                 // finish the parameter declaration
                 buffer.Append(';')
                       .Append("\n\n");
+            }
+
+            if (IncreaseReadability)
+            {
+                commandText = CommandSpacing.Replace(commandText, ", $1");
             }
 
             // only treat 'StoredProcedure' differently since 'Text' may contain 'TableDirect' or 'StoredProcedure'

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -21,9 +21,9 @@ namespace StackExchange.Profiling.SqlFormatters
         public bool IncludeParameterValues { get; set; } = true;
 
         /// <summary>
-        /// Modifies the output query to increase readibility by adding spaces around crowded commas.
+        /// Modifies the output query by adding spaces after commas.
         /// </summary>
-        public bool IncreaseReadability { get; set; } = true;
+        public bool SpaceAfterComma { get; set; } = true;
 
         /// <summary>
         /// Lookup a function for translating a parameter by parameter type
@@ -120,7 +120,7 @@ namespace StackExchange.Profiling.SqlFormatters
                       .Append("\n\n");
             }
 
-            if (IncreaseReadability)
+            if (SpaceAfterComma)
             {
                 commandText = CommandSpacing.Replace(commandText, ", $1");
             }

--- a/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
+++ b/src/MiniProfiler.Shared/SqlFormatters/SqlServerFormatter.cs
@@ -21,9 +21,9 @@ namespace StackExchange.Profiling.SqlFormatters
         public bool IncludeParameterValues { get; set; } = true;
 
         /// <summary>
-        /// Modifies the output query by adding spaces after commas.
+        /// Whether to modify the output query by adding spaces after commas.
         /// </summary>
-        public bool SpaceAfterComma { get; set; } = true;
+        public bool InsertSpacesAfterCommas { get; set; } = true;
 
         /// <summary>
         /// Lookup a function for translating a parameter by parameter type
@@ -120,7 +120,7 @@ namespace StackExchange.Profiling.SqlFormatters
                       .Append("\n\n");
             }
 
-            if (SpaceAfterComma)
+            if (InsertSpacesAfterCommas)
             {
                 commandText = CommandSpacing.Replace(commandText, ", $1");
             }

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -93,7 +93,7 @@ namespace StackExchange.Profiling.Tests
         {
             var formatter = new InlineFormatter()
             {
-                IncreaseReadability = false
+                SpaceAfterComma = false
             };
             var parameters = new List<SqlTimingParameter>
             {
@@ -119,11 +119,11 @@ namespace StackExchange.Profiling.Tests
         }
 
         [Fact]
-        public void InlineIncreaseReadabilityEnabled()
+        public void InlineSpaceAfterCommaEnabled()
         {
             var formatter = new InlineFormatter()
             {
-                IncreaseReadability = true
+                SpaceAfterComma = true
             };
             var parameters = new List<SqlTimingParameter>
             {
@@ -136,11 +136,11 @@ namespace StackExchange.Profiling.Tests
         }
 
         [Fact]
-        public void InlineIncreaseReadabilityDisabled()
+        public void InlineSpaceAfterCommaDisabled()
         {
             var formatter = new InlineFormatter()
             {
-                IncreaseReadability = false
+                SpaceAfterComma = false
             };
             var parameters = new List<SqlTimingParameter>
             {
@@ -264,7 +264,7 @@ namespace StackExchange.Profiling.Tests
 
         [Theory]
         [MemberData(nameof(GetParamPrefixes))]
-        public void TableQueryWithIncreasedReadabilityEnabled(string at)
+        public void TableQueryWithSpaceAfterCommaEnabled(string at)
         {
             const string text = "select 1 from dbo.Table where x = @x,y = @y";
             var cmd = CreateDbCommand(CommandType.Text, text);
@@ -273,7 +273,7 @@ namespace StackExchange.Profiling.Tests
 
             var formatter = new SqlServerFormatter()
             {
-                IncreaseReadability = true
+                SpaceAfterComma = true
             };
             var actualOutput = GenerateOutput(formatter, cmd, text);
 
@@ -283,7 +283,7 @@ namespace StackExchange.Profiling.Tests
 
         [Theory]
         [MemberData(nameof(GetParamPrefixes))]
-        public void TableQueryWithIncreasedReadabilityDisabled(string at)
+        public void TableQueryWithSpaceAfterCommaDisabled(string at)
         {
             const string text = "select 1 from dbo.Table where x = @x,y = @y";
             var cmd = CreateDbCommand(CommandType.Text, text);
@@ -292,7 +292,7 @@ namespace StackExchange.Profiling.Tests
 
             var formatter = new SqlServerFormatter()
             {
-                IncreaseReadability = false
+                SpaceAfterComma = false
             };
             var actualOutput = GenerateOutput(formatter, cmd, text);
 

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -228,6 +228,44 @@ namespace StackExchange.Profiling.Tests
 
         [Theory]
         [MemberData(nameof(GetParamPrefixes))]
+        public void TableQueryWithIncreasedReadabilityEnabled(string at)
+        {
+            const string text = "select 1 from dbo.Table where x = @x,y = @y";
+            var cmd = CreateDbCommand(CommandType.Text, text);
+            AddDbParameter<int>(cmd, at + "x", 123);
+            AddDbParameter<long>(cmd, at + "y", 123);
+
+            var formatter = new SqlServerFormatter()
+            {
+                IncreaseReadability = true
+            };
+            var actualOutput = GenerateOutput(formatter, cmd, text);
+
+            const string expectedOutput = "DECLARE @x int = 123,\n        @y bigint = 123;\n\nselect 1 from dbo.Table where x = @x, y = @y;";
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetParamPrefixes))]
+        public void TableQueryWithIncreasedReadabilityDisabled(string at)
+        {
+            const string text = "select 1 from dbo.Table where x = @x,y = @y";
+            var cmd = CreateDbCommand(CommandType.Text, text);
+            AddDbParameter<int>(cmd, at + "x", 123);
+            AddDbParameter<long>(cmd, at + "y", 123);
+
+            var formatter = new SqlServerFormatter()
+            {
+                IncreaseReadability = false
+            };
+            var actualOutput = GenerateOutput(formatter, cmd, text);
+
+            const string expectedOutput = "DECLARE @x int = 123,\n        @y bigint = 123;\n\nselect 1 from dbo.Table where x = @x,y = @y;";
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetParamPrefixes))]
         public void TableQueryWithBit(string at)
         {
             const string text = "select 1 from dbo.Table where x = @x, y = @y";

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -116,11 +116,11 @@ namespace StackExchange.Profiling.Tests
         }
 
         [Fact]
-        public void InlineSpaceAfterCommaEnabled()
+        public void InlineSpacesAfterCommasEnabled()
         {
             var formatter = new InlineFormatter()
             {
-                SpaceAfterComma = true
+                InsertSpacesAfterCommas = true
             };
             var parameters = new List<SqlTimingParameter>
             {
@@ -133,11 +133,11 @@ namespace StackExchange.Profiling.Tests
         }
 
         [Fact]
-        public void InlineSpaceAfterCommaDisabled()
+        public void InlineSpacesAfterCommasDisabled()
         {
             var formatter = new InlineFormatter()
             {
-                SpaceAfterComma = false
+                InsertSpacesAfterCommas = false
             };
             var parameters = new List<SqlTimingParameter>
             {
@@ -261,7 +261,7 @@ namespace StackExchange.Profiling.Tests
 
         [Theory]
         [MemberData(nameof(GetParamPrefixes))]
-        public void TableQueryWithSpaceAfterCommaEnabled(string at)
+        public void TableQueryWithSpacesAfterCommasEnabled(string at)
         {
             const string text = "select 1 from dbo.Table where x = @x,y = @y";
             var cmd = CreateDbCommand(CommandType.Text, text);
@@ -270,7 +270,7 @@ namespace StackExchange.Profiling.Tests
 
             var formatter = new SqlServerFormatter()
             {
-                SpaceAfterComma = true
+                InsertSpacesAfterCommas = true
             };
             var actualOutput = GenerateOutput(formatter, cmd, text);
 
@@ -280,7 +280,7 @@ namespace StackExchange.Profiling.Tests
 
         [Theory]
         [MemberData(nameof(GetParamPrefixes))]
-        public void TableQueryWithSpaceAfterCommaDisabled(string at)
+        public void TableQueryWithSpacesAfterCommasDisabled(string at)
         {
             const string text = "select 1 from dbo.Table where x = @x,y = @y";
             var cmd = CreateDbCommand(CommandType.Text, text);
@@ -289,7 +289,7 @@ namespace StackExchange.Profiling.Tests
 
             var formatter = new SqlServerFormatter()
             {
-                SpaceAfterComma = false
+                InsertSpacesAfterCommas = false
             };
             var actualOutput = GenerateOutput(formatter, cmd, text);
 

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -91,7 +91,10 @@ namespace StackExchange.Profiling.Tests
         [Fact]
         public void InlineParameterNamesInParameterValues()
         {
-            var formatter = new InlineFormatter();
+            var formatter = new InlineFormatter()
+            {
+                IncreaseReadability = false
+            };
             var parameters = new List<SqlTimingParameter>
             {
                 new SqlTimingParameter() { DbType = "string", Name = "url", Value = "http://www.example.com?myid=1" },
@@ -101,7 +104,6 @@ namespace StackExchange.Profiling.Tests
             var formatted = formatter.FormatSql(command, parameters);
             Assert.Equal("SELECT * FROM urls WHERE url = 'http://www.example.com?myid=1' OR myid = '1'", formatted);
         }
-
         [Fact]
         public void InlineParameterValuesDisplayNullForStrings()
         {
@@ -114,6 +116,40 @@ namespace StackExchange.Profiling.Tests
             const string command = "SELECT * FROM urls WHERE url = @url OR @myid IS NULL";
             var formatted = formatter.FormatSql(command, parameters);
             Assert.Equal("SELECT * FROM urls WHERE url = 'http://www.example.com?myid=1' OR null IS NULL", formatted);
+        }
+
+        [Fact]
+        public void InlineIncreaseReadabilityEnabled()
+        {
+            var formatter = new InlineFormatter()
+            {
+                IncreaseReadability = true
+            };
+            var parameters = new List<SqlTimingParameter>
+            {
+                new SqlTimingParameter() { DbType = "string", Name = "url", Value = "http://www.example.com?myid=1" },
+                new SqlTimingParameter() { DbType = "string", Name = "myid", Value = "1" }
+            };
+            const string command = "SELECT myid,url FROM urls WHERE url = @url OR myid = @myid";
+            var formatted = formatter.FormatSql(command, parameters);
+            Assert.Equal("SELECT myid, url FROM urls WHERE url = 'http://www.example.com?myid=1' OR myid = '1'", formatted);
+        }
+
+        [Fact]
+        public void InlineIncreaseReadabilityDisabled()
+        {
+            var formatter = new InlineFormatter()
+            {
+                IncreaseReadability = false
+            };
+            var parameters = new List<SqlTimingParameter>
+            {
+                new SqlTimingParameter() { DbType = "string", Name = "url", Value = "http://www.example.com?myid=1" },
+                new SqlTimingParameter() { DbType = "string", Name = "myid", Value = "1" }
+            };
+            const string command = "SELECT myid,url FROM urls WHERE url = @url OR myid = @myid";
+            var formatted = formatter.FormatSql(command, parameters);
+            Assert.Equal("SELECT myid,url FROM urls WHERE url = 'http://www.example.com?myid=1' OR myid = '1'", formatted);
         }
 
         [Fact]

--- a/tests/MiniProfiler.Tests/SqlFormatterTests.cs
+++ b/tests/MiniProfiler.Tests/SqlFormatterTests.cs
@@ -91,10 +91,7 @@ namespace StackExchange.Profiling.Tests
         [Fact]
         public void InlineParameterNamesInParameterValues()
         {
-            var formatter = new InlineFormatter()
-            {
-                SpaceAfterComma = false
-            };
+            var formatter = new InlineFormatter();
             var parameters = new List<SqlTimingParameter>
             {
                 new SqlTimingParameter() { DbType = "string", Name = "url", Value = "http://www.example.com?myid=1" },


### PR DESCRIPTION
Fixes #539 

Default is enabled, like the existing GetReadableCommand logic.