### PR TITLE
Fix for #560 - propagate  nonce to <link>

### DIFF
--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -8,6 +8,7 @@ This page tracks major changes included in any update starting with version 4.0.
 #### Unreleased
 - **New**:
   - Added an option to control `SpacesAfterCommas` to `InlineSqlFormatter` and `SqlServerFormatter` ([#549](https://github.com/MiniProfiler/dotnet/pull/549) - thanks [Turnerj](https://github.com/Turnerj))
+  - Fixed `nonce` attribute propagation to generated `<link>` style element for full CSP support ([#565](https://github.com/MiniProfiler/dotnet/pull/565))
 
 #### Version 4.2.1
 - **New**:

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -111,6 +111,7 @@ namespace StackExchange.Profiling {
         ids: string[];
         ignoredDuplicateExecuteTypes: string[];
         maxTracesToShow: number;
+        nonce: string;
         path: string;
         renderPosition: RenderPosition;
         showChildrenTime: boolean;
@@ -298,6 +299,7 @@ namespace StackExchange.Profiling {
                 toggleShortcut: data.toggleShortcut,
                 startHidden: bool(data.startHidden),
                 ignoredDuplicateExecuteTypes: (data.ignoredDuplicateExecuteTypes || '').split(','),
+                nonce: script.nonce,
             };
 
             function doInit() {
@@ -372,7 +374,7 @@ namespace StackExchange.Profiling {
                     } else {
                         alreadyDone = true;
                         if (mp.options.authorized) {
-                            document.head.insertAdjacentHTML('beforeend', `<link rel="stylesheet" type="text/css" href="${mp.options.path}includes.min.css?v=${mp.options.version}" />`);
+                            document.head.insertAdjacentHTML('beforeend', `<link rel="stylesheet" type="text/css" href="${mp.options.path}includes.min.css?v=${mp.options.version}" ${mp.options.nonce ? `nonce="${mp.options.nonce}" ` : ''}/>`);
                         }
                         doInit();
                     }


### PR DESCRIPTION
This propagates the `nonce` attribute to the generated <link> element as it should for proper CSP handling.