### PR TITLE
IDbProfiler not adding to _inProgress if timing is null

### DIFF
--- a/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
@@ -25,6 +25,12 @@ namespace StackExchange.Profiling
         {
             var id = Tuple.Create((object)profiledDbCommand, executeType);
             var timing = profiledDbCommand.GetTiming(executeType.ToString(), this);
+            
+            if(timing == null)
+            {
+                return;
+            }
+            
             lock (_dbLocker)
             {
                 _inProgress ??= new Dictionary<Tuple<object, SqlExecuteType>, CustomTiming>();

--- a/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.IDbProfiler.cs
@@ -26,7 +26,7 @@ namespace StackExchange.Profiling
             var id = Tuple.Create((object)profiledDbCommand, executeType);
             var timing = profiledDbCommand.GetTiming(executeType.ToString(), this);
             
-            if(timing == null)
+            if (timing == null)
             {
                 return;
             }


### PR DESCRIPTION
We are getting the following null reference exceptions:

```
System.NullReferenceException
HResult=0x80004003
Message=Object reference not set to an instance of an object.
Source=MiniProfiler.Shared
StackTrace:
at StackExchange.Profiling.MiniProfiler.StackExchange.Profiling.Data.IDbProfiler.ExecuteFinish(IDbCommand profiledDbCommand, SqlExecuteType executeType, DbDataReader reader) in C:\projects\dotnet\src\MiniProfiler.Shared\MiniProfiler.IDbProfiler.cs:line 75
at StackExchange.Profiling.Data.ProfiledDbCommand.ExecuteNonQuery() in C:\projects\dotnet\src\MiniProfiler.Shared\Data\ProfiledDbCommand.cs:line 297
at Dapper.SqlMapper.ExecuteCommand(IDbConnection cnn, CommandDefinition& command, Action`2 paramReader) in /_/Dapper/SqlMapper.cs:line 2813
at Dapper.SqlMapper.ExecuteImpl(IDbConnection cnn, CommandDefinition& command) in /_/Dapper/SqlMapper.cs:line 572
at Dapper.SqlMapper.Execute(IDbConnection cnn, String sql, Object param, IDbTransaction transaction, Nullable`1 commandTimeout, Nullable`1 commandType) in /_/Dapper/SqlMapper.cs:line 443
```

From the looks of things, looks like `profiledDbCommand.GetTiming(executeType.ToString(), this);` can return null, which we then add. Later on we use this `CustomTiming` inside `IDbProfiler.ExecuteFinish` without null checking.

It doesn't make sense adding a null to that collection imho?