### PR TITLE
Fix #592 double quotes on data-position attribute

### DIFF
--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -175,7 +175,6 @@ namespace StackExchange.Profiling.Internal
 
             sb.Append("\" data-position=\"");
             sb.Append((position ?? options.PopupRenderPosition).ToString());
-            sb.Append('"');
 
             sb.Append("\" data-scheme=\"");
             sb.Append(options.ColorScheme.ToString());


### PR DESCRIPTION
This was partially fixed in #497 but not for the other overload of this function.