### PR TITLE
Refactoring MiniProfilerBaseOptionsExtensions.ExpireAndGetUnviewedAsync

### DIFF
--- a/src/MiniProfiler.AspNetCore/Storage/MemoryCacheStorage.cs
+++ b/src/MiniProfiler.AspNetCore/Storage/MemoryCacheStorage.cs
@@ -249,5 +249,18 @@ namespace StackExchange.Profiling.Storage
             SetViewed(user, id);
             return Task.CompletedTask;
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
+++ b/src/MiniProfiler.Providers.MongoDB/MongoDbStorage.cs
@@ -252,6 +252,19 @@ namespace StackExchange.Profiling
             var set = Builders<MiniProfiler>.Update.Set(profiler => profiler.HasUserViewed, true);
             await _collection.UpdateOneAsync(p => p.Id == id, set).ConfigureAwait(false);
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// Returns the underlying client.

--- a/src/MiniProfiler.Providers.RavenDB/RavenDbStorage.cs
+++ b/src/MiniProfiler.Providers.RavenDB/RavenDbStorage.cs
@@ -308,6 +308,19 @@ namespace StackExchange.Profiling.Storage
             profile.HasUserViewed = true;
             await session.SaveChangesAsync().ConfigureAwait(false);
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// Asynchronously returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.

--- a/src/MiniProfiler.Providers.Redis/RedisStorage.cs
+++ b/src/MiniProfiler.Providers.Redis/RedisStorage.cs
@@ -261,6 +261,19 @@ namespace StackExchange.Profiling.Storage
             RedisValue value = id.ToString();
             return _database.SetRemoveAsync(key, value);
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// Asynchronously returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.

--- a/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptionsExtensions.cs
+++ b/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptionsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace StackExchange.Profiling.Internal
@@ -23,7 +24,7 @@ namespace StackExchange.Profiling.Internal
             {
                 for (var i = 0; i < ids.Count - options.MaxUnviewedProfiles; i++)
                 {
-                    options.Storage.SetViewedAsync(user, ids[i]);
+                    options.Storage.SetViewed(user, ids[i]);
                 }
             }
             return ids;
@@ -45,10 +46,8 @@ namespace StackExchange.Profiling.Internal
             var ids = await options.Storage.GetUnviewedIdsAsync(user).ConfigureAwait(false);
             if (ids?.Count > options.MaxUnviewedProfiles)
             {
-                for (var i = 0; i < ids.Count - options.MaxUnviewedProfiles; i++)
-                {
-                    await options.Storage.SetViewedAsync(user, ids[i]).ConfigureAwait(false);
-                }
+                var idsToSetViewed = ids.Take(ids.Count - options.MaxUnviewedProfiles);
+                await options.Storage.SetViewedAsync(user, idsToSetViewed).ConfigureAwait(false);
             }
             return ids;
         }

--- a/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
+++ b/src/MiniProfiler.Shared/Storage/DatabaseStorageBase.cs
@@ -122,6 +122,19 @@ namespace StackExchange.Profiling.Storage
         public abstract Task SetViewedAsync(string user, Guid id);
 
         /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public virtual async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.
         /// </summary>
         /// <param name="user">User identified by the current <c>MiniProfilerOptions.UserProvider</c>.</param>

--- a/src/MiniProfiler.Shared/Storage/IAsyncStorage.cs
+++ b/src/MiniProfiler.Shared/Storage/IAsyncStorage.cs
@@ -126,6 +126,13 @@ namespace StackExchange.Profiling.Storage
         /// <param name="user">The user to set this profiler ID as viewed for.</param>
         /// <param name="id">The profiler ID to set viewed.</param>
         Task SetViewedAsync(string user, Guid id);
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        Task SetViewedAsync(string user, IEnumerable<Guid> ids);
 
         /// <summary>
         /// Asynchronously returns a list of <see cref="MiniProfiler.Id"/>s that haven't been seen by <paramref name="user"/>.

--- a/src/MiniProfiler.Shared/Storage/MultiStorageProvider.cs
+++ b/src/MiniProfiler.Shared/Storage/MultiStorageProvider.cs
@@ -243,6 +243,19 @@ namespace StackExchange.Profiling.Storage
 
             return Task.WhenAll(Stores.Select(s => s.SetViewedAsync(user, id)));
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// Runs <see cref="IAsyncStorage.GetUnviewedIds"/> on each <see cref="IAsyncStorage"/> object in <see cref="Stores"/> and returns the Union of results.

--- a/src/MiniProfiler.Shared/Storage/NullStorage.cs
+++ b/src/MiniProfiler.Shared/Storage/NullStorage.cs
@@ -89,6 +89,13 @@ namespace StackExchange.Profiling.Storage
         public Task SetViewedAsync(string user, Guid id) => Task.CompletedTask;
 
         /// <summary>
+        /// Sets nothing.
+        /// </summary>
+        /// <param name="user">No one cares.</param>
+        /// <param name="ids">No one cares.</param>
+        public Task SetViewedAsync(string user, IEnumerable<Guid> ids) => Task.CompletedTask;
+
+        /// <summary>
         /// Gets nothing.
         /// </summary>
         /// <param name="user">No one cares.</param>

--- a/src/MiniProfiler/Storage/MemoryCacheStorage.cs
+++ b/src/MiniProfiler/Storage/MemoryCacheStorage.cs
@@ -243,5 +243,18 @@ namespace StackExchange.Profiling.Storage
             SetViewed(user, id);
             return Task.CompletedTask;
         }
+        
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        public async Task SetViewedAsync(string user, IEnumerable<Guid> ids)
+        {
+            foreach (var id in ids)
+            {
+                await this.SetViewedAsync(user, id).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/tests/MiniProfiler.Tests/InternalErrorTests.cs
+++ b/tests/MiniProfiler.Tests/InternalErrorTests.cs
@@ -60,6 +60,7 @@ namespace StackExchange.Profiling.Tests
         public Task SetUnviewedAsync(string user, Guid id) => throw new BoomBoom();
         public void SetViewed(string user, Guid id) => throw new BoomBoom();
         public Task SetViewedAsync(string user, Guid id) => throw new BoomBoom();
+        public Task SetViewedAsync(string user, IEnumerable<Guid> ids) => throw new BoomBoom();
 
         public class BoomBoom : Exception { }
     }


### PR DESCRIPTION
Refactoring `MiniProfilerBaseOptionsExtensions.ExpireAndGetUnviewedAsync` to utilize a new overload of `IAsyncStorage.SetViewedAsync` that accepts multiple ids.
Adding `PostgreSqlStorage` implementation that can set multiple profilers as viewed in a single query.

This query is called a lot, so trying to reduce database round trips.