### PR TITLE
New IAdvancedAsyncStorage interface

### DIFF
--- a/src/MiniProfiler.Shared/Storage/IAdvancedAsyncStorage.cs
+++ b/src/MiniProfiler.Shared/Storage/IAdvancedAsyncStorage.cs
@@ -2,17 +2,18 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace StackExchange.Profiling.Storage;
-
-/// <summary>
-/// Provides saving and loading <see cref="MiniProfiler"/>s to a storage medium with some advanced operations.
-/// </summary>
-public interface IAdvancedAsyncStorage : IAsyncStorage
+namespace StackExchange.Profiling.Storage
 {
     /// <summary>
-    /// Asynchronously sets the provided profiler sessions to "viewed"
+    /// Provides saving and loading <see cref="MiniProfiler"/>s to a storage medium with some advanced operations.
     /// </summary>
-    /// <param name="user">The user to set this profiler ID as viewed for.</param>
-    /// <param name="ids">The profiler IDs to set viewed.</param>
-    Task SetViewedAsync(string user, IEnumerable<Guid> ids);
+    public interface IAdvancedAsyncStorage : IAsyncStorage
+    {
+        /// <summary>
+        /// Asynchronously sets the provided profiler sessions to "viewed"
+        /// </summary>
+        /// <param name="user">The user to set this profiler ID as viewed for.</param>
+        /// <param name="ids">The profiler IDs to set viewed.</param>
+        Task SetViewedAsync(string user, IEnumerable<Guid> ids);
+    }
 }

--- a/src/MiniProfiler.Shared/Storage/IAdvancedAsyncStorage.cs
+++ b/src/MiniProfiler.Shared/Storage/IAdvancedAsyncStorage.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StackExchange.Profiling.Storage;
+
+/// <summary>
+/// Provides saving and loading <see cref="MiniProfiler"/>s to a storage medium with some advanced operations.
+/// </summary>
+public interface IAdvancedAsyncStorage : IAsyncStorage
+{
+    /// <summary>
+    /// Asynchronously sets the provided profiler sessions to "viewed"
+    /// </summary>
+    /// <param name="user">The user to set this profiler ID as viewed for.</param>
+    /// <param name="ids">The profiler IDs to set viewed.</param>
+    Task SetViewedAsync(string user, IEnumerable<Guid> ids);
+}

--- a/src/MiniProfiler.Shared/Storage/NullStorage.cs
+++ b/src/MiniProfiler.Shared/Storage/NullStorage.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Profiling.Storage
     /// <summary>
     /// Empty storage no-nothing provider for doing nothing at all. Super efficient.
     /// </summary>
-    public class NullStorage : IAsyncStorage
+    public class NullStorage : IAdvancedAsyncStorage
     {
         /// <summary>
         /// Returns no profilers.
@@ -87,6 +87,13 @@ namespace StackExchange.Profiling.Storage
         /// <param name="user">No one cares.</param>
         /// <param name="id">No one cares.</param>
         public Task SetViewedAsync(string user, Guid id) => Task.CompletedTask;
+
+        /// <summary>
+        /// Sets nothing.
+        /// </summary>
+        /// <param name="user">No one cares.</param>
+        /// <param name="ids">No one cares.</param>
+        public Task SetViewedAsync(string user, IEnumerable<Guid> ids) => Task.CompletedTask;
 
         /// <summary>
         /// Gets nothing.


### PR DESCRIPTION
Taking the comments from: https://github.com/MiniProfiler/dotnet/pull/617

In order to not break existing implementations of `IAsyncStorage`, this PR proposes the new interface `IAdvancedAsyncStorage` which inherits IAsyncStorage and seeks to provide some additional functionality.

The idea would be to merge IAsyncStorage and IAdvancedAsyncStorage in a future release.