### PR TITLE
Eliminate the use of inline styles, making it compatible with strict CSP for style.

### DIFF
--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -6,6 +6,8 @@ layout: "default"
 This page tracks major changes included in any update starting with version 4.0.0.3
 
 #### Unreleased
+- **New**:
+  - Support for strict CSP (dynamic inline styles removed) ([#634](https://github.com/MiniProfiler/dotnet/pull/634) - thanks [rwasef1830](https://github.com/rwasef1830))
 - **Fixes/Changes**: 
   - Upgraded MongoDB driver, allowing automatic index creation and profiler expiration ([#613](https://github.com/MiniProfiler/dotnet/pull/613) - thanks [IanKemp](https://github.com/IanKemp))
 

--- a/samples/Samples.AspNet/Helpers/NonceService.cs
+++ b/samples/Samples.AspNet/Helpers/NonceService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Samples.AspNetCore
+{
+    /// <summary>
+    /// Nonce service (custom implementation) for sharing a random nonce for the lifetime of a request.
+    /// </summary>
+    public class NonceService
+    {
+        public string RequestNonce { get; } = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
+    }
+
+    public static class NonceExtensions
+    {
+        public static string? GetNonce(this HttpContext context) => context.RequestServices.GetService<NonceService>()?.RequestNonce;
+    }
+}

--- a/samples/Samples.AspNet/Pages/RazorPagesSample.cshtml
+++ b/samples/Samples.AspNet/Pages/RazorPagesSample.cshtml
@@ -13,7 +13,7 @@
     <partial name="Index.RightPanel" />
 </div>
 @section scripts {
-    <script>
+    <script nonce="@HttpContext.GetNonce()">
         $(function () {
             // these links should fire ajax requests, not do navigation
             $('.ajax-requests a').click(function () {

--- a/samples/Samples.AspNet/Views/Shared/Index.cshtml
+++ b/samples/Samples.AspNet/Views/Shared/Index.cshtml
@@ -11,7 +11,7 @@
     <partial name="Index.RightPanel" />
 </div>
 @section scripts {
-<script>
+<script nonce="@Context.GetNonce()">
     $(function () {
         // these links should fire ajax requests, not do navigation
         $('.ajax-requests a').click(function () {

--- a/samples/Samples.AspNet/Views/Shared/_Layout.cshtml
+++ b/samples/Samples.AspNet/Views/Shared/_Layout.cshtml
@@ -47,7 +47,7 @@
     @RenderSection("scripts", required: false)
 
     @* Simple options are exposed...or make a full options class for customizing. *@
-    <mini-profiler position="@RenderPosition.Right" max-traces="5" color-scheme="ColorScheme.Auto" nonce="45" decimal-places="2" />
+    <mini-profiler position="@RenderPosition.Right" max-traces="5" color-scheme="ColorScheme.Auto" decimal-places="2" />
     @*<mini-profiler options="new RenderOptions { Position = RenderPosition.Right, MaxTracesToShow = 5, ColorScheme = ColorScheme.Auto }" />*@
 </body>
 </html>

--- a/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
@@ -35,6 +35,7 @@ namespace StackExchange.Profiling
                 path: context.Request.PathBase + path,
                 isAuthorized: state?.IsAuthorized ?? false,
                 renderOptions,
+                context.RequestServices,
                 requestIDs: state?.RequestIDs);
 
             return new HtmlString(result);

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -406,7 +406,7 @@ namespace StackExchange.Profiling
             else
             {
                 context.Response.ContentType = "text/html; charset=utf-8";
-                return Render.SingleResultHtml(profiler, context.Request.PathBase + Options.RouteBasePath.Value.EnsureTrailingSlash());
+                return Render.SingleResultHtml(profiler, context.RequestServices, context.Request.PathBase + Options.RouteBasePath.Value.EnsureTrailingSlash());
             }
         }
     }

--- a/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerMiddleware.cs
@@ -291,7 +291,7 @@ namespace StackExchange.Profiling
             context.Response.ContentType = "text/html; charset=utf-8";
 
             var path = context.Request.PathBase + Options.RouteBasePath.Value.EnsureTrailingSlash();
-            return Render.ResultListHtml(Options, path);
+            return Render.ResultListHtml(Options, context.RequestServices, path);
         }
 
         /// <summary>

--- a/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
+++ b/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Web;
 using StackExchange.Profiling.Data;
 using StackExchange.Profiling.Helpers;
 using StackExchange.Profiling.SqlFormatters;

--- a/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
+++ b/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
@@ -230,7 +230,7 @@ namespace StackExchange.Profiling.Internal
         /// <summary>
         /// Called whenever a nonce is required for a script or style tag for each request.
         /// </summary>
-        public Func<IServiceProvider, string?> NonceGetter { get; set; } = _ => null; 
+        public Func<IServiceProvider, string?> NonceProvider { get; set; } = _ => null;
 
         /// <summary>
         /// Called when passed to <see cref="MiniProfiler.Configure{T}(T)"/>.

--- a/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
+++ b/src/MiniProfiler.Shared/Internal/MiniProfilerBaseOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Web;
 using StackExchange.Profiling.Data;
 using StackExchange.Profiling.Helpers;
 using StackExchange.Profiling.SqlFormatters;
@@ -226,6 +227,11 @@ namespace StackExchange.Profiling.Internal
         /// The <cref see="IDiposable.Dispose" /> method of the returned object is called at the same time as the <cref see="Timing" /> is <cref see="Timing.Stop" />ed.
         /// </summary>
         public Func<Timing, IDisposable>? TimingInstrumentationProvider { get; set; }
+
+        /// <summary>
+        /// Called whenever a nonce is required for a script or style tag for each request.
+        /// </summary>
+        public Func<IServiceProvider, string?> NonceGetter { get; set; } = _ => null; 
 
         /// <summary>
         /// Called when passed to <see cref="MiniProfiler.Configure{T}(T)"/>.

--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -268,11 +268,7 @@ namespace StackExchange.Profiling.Internal
             {
                 sb.Append(" nonce=\"");
                 sb.Append(HttpUtility.HtmlAttributeEncode(nonce));
-                sb.Append("\" ");
-            }
-            else
-            {
-                sb.Append(' ');
+                sb.Append("\"");
             }
 
             sb.Append(">var profiler = ");

--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Web;
 
 namespace StackExchange.Profiling.Internal
 {
@@ -16,13 +17,15 @@ namespace StackExchange.Profiling.Internal
         /// <param name="profiler">The profiler to render a tag for.</param>
         /// <param name="path">The root path that MiniProfiler is being served from.</param>
         /// <param name="isAuthorized">Whether the current user is authorized for MiniProfiler.</param>
+        /// <param name="serviceProvider">The current http request service provider</param>
         /// <param name="renderOptions">The option overrides (if any) to use rendering this MiniProfiler.</param>
         /// <param name="requestIDs">The request IDs to fetch for this render.</param>
         public static string Includes(
             MiniProfiler profiler,
             string path,
             bool isAuthorized,
-            RenderOptions renderOptions,
+            RenderOptions? renderOptions,
+            IServiceProvider? serviceProvider = null,
             List<Guid>? requestIDs = null)
         {
             var sb = StringBuilderCache.Get();
@@ -84,9 +87,12 @@ namespace StackExchange.Profiling.Internal
             {
                 sb.Append(" data-start-hidden=\"true\"");
             }
-            if (renderOptions?.Nonce.HasValue() ?? false)
+
+            var nonce = renderOptions?.Nonce ??
+                        (serviceProvider != null ? profiler.Options.NonceGetter(serviceProvider) : null);
+            if (nonce?.HasValue() ?? false)
             {
-                sb.Append(" nonce=\"").Append(System.Web.HttpUtility.HtmlAttributeEncode(renderOptions.Nonce)).Append("\"");
+                sb.Append(" nonce=\"").Append(HttpUtility.HtmlAttributeEncode(nonce)).Append("\"");
             }
 
             sb.Append(" data-max-traces=\"");
@@ -131,6 +137,7 @@ namespace StackExchange.Profiling.Internal
         /// <param name="maxTracesToShow">The maximum number of profilers to show (before the oldest is removed - defaults to <see cref="MiniProfilerBaseOptions.PopupMaxTracesToShow"/>).</param>
         /// <param name="showControls">Whether to show the controls (defaults to <see cref="MiniProfilerBaseOptions.ShowControls"/>).</param>
         /// <param name="startHidden">Whether to start hidden (defaults to <see cref="MiniProfilerBaseOptions.PopupStartHidden"/>).</param>
+        /// <param name="nonce">Content script policy nonce value to use for script and style tags generated.</param>
         public static string Includes(
             MiniProfiler profiler,
             string path,
@@ -141,12 +148,22 @@ namespace StackExchange.Profiling.Internal
             bool? showTimeWithChildren = null,
             int? maxTracesToShow = null,
             bool? showControls = null,
-            bool? startHidden = null)
+            bool? startHidden = null,
+            string? nonce = null)
         {
             var sb = StringBuilderCache.Get();
             var options = profiler.Options;
 
-            sb.Append("<script async=\"async\" id=\"mini-profiler\" src=\"");
+            sb.Append("<script");
+            
+            if (!string.IsNullOrWhiteSpace(nonce))
+            {
+                sb.Append(" nonce=\"");
+                sb.Append(HttpUtility.HtmlAttributeEncode(nonce));
+                sb.Append("\"");
+            }
+
+            sb.Append(" async=\"async\" id=\"mini-profiler\" src=\"");
             sb.Append(path);
             sb.Append("includes.min.js?v=");
             sb.Append(options.VersionHash);
@@ -233,19 +250,35 @@ namespace StackExchange.Profiling.Internal
         /// Renders a full HTML page for the share link in MiniProfiler.
         /// </summary>
         /// <param name="profiler">The profiler to render a tag for.</param>
+        /// <param name="serviceProvider">The current request service provider.</param>
         /// <param name="path">The root path that MiniProfiler is being served from.</param>
         /// <returns>A full HTML page for this MiniProfiler.</returns>
-        public static string SingleResultHtml(MiniProfiler profiler, string path)
+        public static string SingleResultHtml(MiniProfiler profiler, IServiceProvider serviceProvider, string path)
         {
+            var nonce = profiler.Options.NonceGetter(serviceProvider) ?? string.Empty;
+            
             var sb = StringBuilderCache.Get();
             sb.Append("<html><head><title>");
             sb.Append(profiler.Name);
             sb.Append(" (");
             sb.Append(profiler.DurationMilliseconds.ToString(CultureInfo.InvariantCulture));
-            sb.Append(" ms) - Profiling Results</title><script>var profiler = ");
+            sb.Append(" ms) - Profiling Results</title><script");
+
+            if (!string.IsNullOrWhiteSpace(nonce))
+            {
+                sb.Append(" nonce=\"");
+                sb.Append(HttpUtility.HtmlAttributeEncode(nonce));
+                sb.Append("\" ");
+            }
+            else
+            {
+                sb.Append(' ');
+            }
+
+            sb.Append(">var profiler = ");
             sb.Append(profiler.ToJson(htmlEscape: true));
             sb.Append(";</script>");
-            sb.Append(Includes(profiler, path: path, isAuthorized: true));
+            sb.Append(Includes(profiler, path: path, isAuthorized: true, nonce: nonce));
             sb.Append(@"</head><body><div class=""mp-result-full""></div></body></html>");
             return sb.ToString();
         }

--- a/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
+++ b/src/MiniProfiler.Shared/MiniProfiler.Shared.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" PrivateAssets="all" />
+    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" PrivateAssets="all" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.7.2" PrivateAssets="all" />
   </ItemGroup>
   

--- a/src/MiniProfiler.Shared/ui/includes.css
+++ b/src/MiniProfiler.Shared/ui/includes.css
@@ -179,6 +179,9 @@
 .mp-result table.mp-client-timings {
   margin-top: 10px;
 }
+.mp-result table.mp-client-timings th:first-child {
+  text-align: left;
+}
 .mp-result table.mp-client-timings td:nth-child(2) {
   width: 100%;
   padding: 0;

--- a/src/MiniProfiler.Shared/ui/includes.less
+++ b/src/MiniProfiler.Shared/ui/includes.less
@@ -153,6 +153,10 @@
 
     table.mp-client-timings {
         margin-top: 10px;
+		
+		th:first-child {
+			text-align: left;
+		}
 
         td:nth-child(2) {
             width: 100%;

--- a/src/MiniProfiler.Shared/ui/includes.less
+++ b/src/MiniProfiler.Shared/ui/includes.less
@@ -51,7 +51,7 @@
 }
 
 .mp-scheme-light {
-  color-scheme: light;
+    color-scheme: light;
 }
 
 .mp-scheme-dark {
@@ -72,7 +72,6 @@
     --mp-highlight-keyword-color: #36a1ef;
     /* Borders */
     --mp-result-border: solid 0.5px #575757;
-
     color-scheme: dark;
 
     body {
@@ -153,10 +152,10 @@
 
     table.mp-client-timings {
         margin-top: 10px;
-		
-		th:first-child {
-			text-align: left;
-		}
+
+        th:first-child {
+            text-align: left;
+        }
 
         td:nth-child(2) {
             width: 100%;

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -728,7 +728,7 @@ namespace StackExchange.Profiling {
                 let str = `
   <tr class="${timing.IsTrivial ? 'mp-trivial' : ''}${timing.DebugInfo ? ' mp-debug' : ''}" data-timing-id="${timing.Id}">
     <td>${renderDebugInfo(timing)}</td>
-    <td class="mp-label" title="${encode(timing.Name)}"${timing.Depth > 0 ? ` style="padding-left:${timing.Depth * 11}px;"` : ''}>
+    <td class="mp-label" title="${encode(timing.Name)}"${timing.Depth > 0 ? ` data-padding-left="${timing.Depth * 11}px"` : ''}>
       ${encode(timing.Name)}
     </td>
     <td class="mp-duration" title="duration of this step without any children's durations">
@@ -830,7 +830,7 @@ namespace StackExchange.Profiling {
         <table class="mp-timings mp-client-timings">
           <thead>
             <tr>
-              <th style="text-align:left">client event</th>
+              <th>client event</th>
               <th></th>
               <th>duration (ms)</th>
               <th class="mp-more-columns">from start (ms)</th>
@@ -840,7 +840,7 @@ namespace StackExchange.Profiling {
             ${list.map((t) => `
             <tr class="${(t.isTrivial ? 'mp-trivial' : '')}">
               <td class="mp-label">${encode(t.name)}</td>
-              <td class="t-${t.type}${t.point ? ' t-point' : ''}"><div style="margin-left: ${t.left}; width: ${t.width};"></div></td>
+              <td class="t-${t.type}${t.point ? ' t-point' : ''}"><div data-margin-left="${t.left}" data-width="${t.width}"></div></td>
               <td class="mp-duration">
                 ${(t.duration >= 0 ? `<span class="mp-unit"></span>${duration(t.duration, 0)}` : '')}
               </td>
@@ -970,6 +970,16 @@ namespace StackExchange.Profiling {
             for (let i = 0; i < toRemove; i++) {
                 results[i].parentNode.removeChild(results[i]);
             }
+			// dynamic padding, margin and width
+			this.container.querySelectorAll<HTMLElement>("[data-padding-left]").forEach(function (element) {
+				element.style.paddingLeft = element.dataset.paddingLeft;
+			});
+			this.container.querySelectorAll<HTMLElement>("[data-margin-left]").forEach(function (element) {
+				element.style.marginLeft = element.dataset.marginLeft;
+			});
+			this.container.querySelectorAll<HTMLElement>("[data-width]").forEach(function (element) {
+				element.style.width = element.dataset.width;
+			});
         }
 
         private scrollToQuery = (link: HTMLElement, queries: HTMLElement) => {

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -957,11 +957,24 @@ namespace StackExchange.Profiling {
             }
 
             const profilerHtml = this.renderProfiler(json, true);
+			const nonVisibleElement = document.createElement("div");
+			nonVisibleElement.innerHTML = profilerHtml;
+			
+			// dynamic padding, margin and width
+			nonVisibleElement.querySelectorAll<HTMLElement>("[data-padding-left]").forEach(function (element) {
+				element.style.paddingLeft = element.dataset.paddingLeft;
+			});
+			nonVisibleElement.querySelectorAll<HTMLElement>("[data-margin-left]").forEach(function (element) {
+				element.style.marginLeft = element.dataset.marginLeft;
+			});
+			nonVisibleElement.querySelectorAll<HTMLElement>("[data-width]").forEach(function (element) {
+				element.style.width = element.dataset.width;
+			});
 
             if (this.controls) {
-                this.controls.insertAdjacentHTML('beforebegin', profilerHtml);
+                this.controls.insertAdjacentElement('beforebegin', nonVisibleElement.firstElementChild);
             } else {
-                this.container.insertAdjacentHTML('beforeend', profilerHtml);
+                this.container.insertAdjacentElement('beforeend', nonVisibleElement.firstElementChild);
             }
 
             // limit count to maxTracesToShow, remove those before it
@@ -970,16 +983,6 @@ namespace StackExchange.Profiling {
             for (let i = 0; i < toRemove; i++) {
                 results[i].parentNode.removeChild(results[i]);
             }
-			// dynamic padding, margin and width
-			this.container.querySelectorAll<HTMLElement>("[data-padding-left]").forEach(function (element) {
-				element.style.paddingLeft = element.dataset.paddingLeft;
-			});
-			this.container.querySelectorAll<HTMLElement>("[data-margin-left]").forEach(function (element) {
-				element.style.marginLeft = element.dataset.marginLeft;
-			});
-			this.container.querySelectorAll<HTMLElement>("[data-width]").forEach(function (element) {
-				element.style.width = element.dataset.width;
-			});
         }
 
         private scrollToQuery = (link: HTMLElement, queries: HTMLElement) => {

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -355,7 +355,7 @@ namespace StackExchange.Profiling {
                     // profiler will be defined in the full page's head
                     window.profiler.Started = new Date('' + window.profiler.Started); // Ugh, JavaScript
                     const profilerHtml = mp.renderProfiler(window.profiler, false);
-                    mp.container.insertAdjacentHTML('beforeend', profilerHtml);
+                    mp.setStylesAndDisplay(profilerHtml);
 
                     // highight
                     mp.container.querySelectorAll('pre code').forEach(block => mp.highlight(block as HTMLElement));
@@ -957,31 +957,35 @@ namespace StackExchange.Profiling {
             }
 
             const profilerHtml = this.renderProfiler(json, true);
-			const nonVisibleElement = document.createElement("div");
-			nonVisibleElement.innerHTML = profilerHtml;
-			
-			// dynamic padding, margin and width
-			nonVisibleElement.querySelectorAll<HTMLElement>("[data-padding-left]").forEach(function (element) {
-				element.style.paddingLeft = element.dataset.paddingLeft;
-			});
-			nonVisibleElement.querySelectorAll<HTMLElement>("[data-margin-left]").forEach(function (element) {
-				element.style.marginLeft = element.dataset.marginLeft;
-			});
-			nonVisibleElement.querySelectorAll<HTMLElement>("[data-width]").forEach(function (element) {
-				element.style.width = element.dataset.width;
-			});
-
-            if (this.controls) {
-                this.controls.insertAdjacentElement('beforebegin', nonVisibleElement.firstElementChild);
-            } else {
-                this.container.insertAdjacentElement('beforeend', nonVisibleElement.firstElementChild);
-            }
+			this.setStylesAndDisplay(profilerHtml);
 
             // limit count to maxTracesToShow, remove those before it
             const results = this.container.querySelectorAll('.mp-result');
             const toRemove = results.length - this.options.maxTracesToShow;
             for (let i = 0; i < toRemove; i++) {
                 results[i].parentNode.removeChild(results[i]);
+            }
+        }
+        
+        private setStylesAndDisplay(profilerHtml: string) {
+            const nonVisibleElement = document.createElement("div");
+            nonVisibleElement.innerHTML = profilerHtml;
+
+            // dynamic padding, margin and width
+            nonVisibleElement.querySelectorAll<HTMLElement>("[data-padding-left]").forEach(function (element) {
+                element.style.paddingLeft = element.dataset.paddingLeft;
+            });
+            nonVisibleElement.querySelectorAll<HTMLElement>("[data-margin-left]").forEach(function (element) {
+                element.style.marginLeft = element.dataset.marginLeft;
+            });
+            nonVisibleElement.querySelectorAll<HTMLElement>("[data-width]").forEach(function (element) {
+                element.style.width = element.dataset.width;
+            });
+
+            if (this.controls) {
+                this.controls.insertAdjacentElement('beforebegin', nonVisibleElement.firstElementChild);
+            } else {
+                this.container.insertAdjacentElement('beforeend', nonVisibleElement.firstElementChild);
             }
         }
 

--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -319,11 +319,11 @@ namespace StackExchange.Profiling {
 
                         // fetch and render results
                         mp.fetchResults(mp.options.ids);
-                        
+
                         let lsDisplayValue;
                         try {
                             lsDisplayValue = window.localStorage.getItem('MiniProfiler-Display');
-                        } catch(e) { }
+                        } catch (e) { }
 
                         if (lsDisplayValue) {
                             mp.container.style.display = lsDisplayValue;
@@ -957,7 +957,7 @@ namespace StackExchange.Profiling {
             }
 
             const profilerHtml = this.renderProfiler(json, true);
-			this.setStylesAndDisplay(profilerHtml);
+            this.setStylesAndDisplay(profilerHtml);
 
             // limit count to maxTracesToShow, remove those before it
             const results = this.container.querySelectorAll('.mp-result');
@@ -966,7 +966,7 @@ namespace StackExchange.Profiling {
                 results[i].parentNode.removeChild(results[i]);
             }
         }
-        
+
         private setStylesAndDisplay(profilerHtml: string) {
             const nonVisibleElement = document.createElement("div");
             nonVisibleElement.innerHTML = profilerHtml;
@@ -1238,7 +1238,7 @@ namespace StackExchange.Profiling {
                             results.style.display = newValue;
                             try {
                                 window.localStorage.setItem('MiniProfiler-Display', newValue);
-                            } catch(e) { }
+                            } catch (e) { }
                         }
                     }, false);
                 }

--- a/src/MiniProfiler/MiniProfilerHandler.cs
+++ b/src/MiniProfiler/MiniProfilerHandler.cs
@@ -279,7 +279,7 @@ namespace StackExchange.Profiling
         private string ResultsFullPage(HttpContext context, MiniProfiler profiler)
         {
             context.Response.ContentType = "text/html; charset=utf-8";
-            return Render.SingleResultHtml(profiler, VirtualPathUtility.ToAbsolute(Options.RouteBasePath).EnsureTrailingSlash());
+            return Render.SingleResultHtml(profiler, context, VirtualPathUtility.ToAbsolute(Options.RouteBasePath).EnsureTrailingSlash());
         }
 
         private bool TryGetResource(string filename, out string resource)

--- a/src/MiniProfiler/MiniProfilerHandler.cs
+++ b/src/MiniProfiler/MiniProfilerHandler.cs
@@ -143,7 +143,7 @@ namespace StackExchange.Profiling
             context.Response.ContentType = "text/html; charset=utf-8";
 
             var path = VirtualPathUtility.ToAbsolute(Options.RouteBasePath).EnsureTrailingSlash();
-            return Render.ResultListHtml(Options, path);
+            return Render.ResultListHtml(Options, context, path);
         }
 
         /// <summary>

--- a/tests/MiniProfiler.Tests/RenderTests.cs
+++ b/tests/MiniProfiler.Tests/RenderTests.cs
@@ -15,7 +15,7 @@ namespace StackExchange.Profiling.Tests
         {
             var profiler = GetBasicProfiler();
             var renderOptions = new RenderOptions();
-            var result = Render.Includes(profiler, "/", true, renderOptions, new List<Guid>() { profiler.Id });
+            var result = Render.Includes(profiler, "/", true, renderOptions, null, new List<Guid>() { profiler.Id });
             Output.WriteLine("Result: " + result);
 
             Assert.NotNull(result);
@@ -43,7 +43,7 @@ namespace StackExchange.Profiling.Tests
                 TrivialDurationThresholdMilliseconds = 23,
                 DecimalPlaces = 1,
             };
-            var result = Render.Includes(profiler, "/", true, renderOptions, new List<Guid>() { profiler.Id });
+            var result = Render.Includes(profiler, "/", true, renderOptions, null, new List<Guid>() { profiler.Id });
             Output.WriteLine("Result: " + result);
 
             Assert.NotNull(result);


### PR DESCRIPTION
Dear MiniProfiler team,
Thank you for making this project easy to build and fork. 
With this PR MiniProfiler will run under a strict CSP that disallows inline styles and scripts (by using nonce) with zero errors.

It accomplish this by putting dynamically generated style tag values as data attributes, and then later after appending the miniprofiler html, it queries for them and manipulates the style object on Element directly, thus eliminating the need for inline style.