### PR TITLE
Attempt Fix #505 SQL Timings Not Displaying - for ProfiledDbDataAdapt…

### DIFF
--- a/src/MiniProfiler.Shared/Data/ProfiledDbDataAdapter.cs
+++ b/src/MiniProfiler.Shared/Data/ProfiledDbDataAdapter.cs
@@ -91,7 +91,7 @@ namespace StackExchange.Profiling.Data
             }
             finally
             {
-                _profiler.ExecuteFinish(cmd, SqlExecuteType.Reader, TokenReader);
+                _profiler.ExecuteFinish(cmd, SqlExecuteType.Reader, null);
             }
 
             return result;


### PR DESCRIPTION
…er.Fill() called with a dataset

Hi @NickCraver , after some exploring, I dared to post this draft. It helped us to solve the problem with missing stats - issue #505 

In our project, we use ProfiledDbDataAdapter with the DataSet object passed to the FIll() method . It helped us to get rid of not-well-closed timings. The totals are now filled correctly.
