### PR TITLE
Fix problem with showing async method profile

### DIFF
--- a/samples/Samples.ConsoleCore/Program.cs
+++ b/samples/Samples.ConsoleCore/Program.cs
@@ -59,7 +59,9 @@ namespace Samples.Console
                 }
             }
 
-            mp?.Stop();
+            await mp!.StopAsync();
+            WriteLine(MiniProfiler.Current.RenderPlainText());
+
         }
 
         public static void TestMultiThreaded()


### PR DESCRIPTION
In this example we don't have a result for `TestAsync() ` 

since method is async the result of **MiniProfiler.Current is null** in main method so we have to print result inside TestAsync Method