### PR TITLE
Allow additional headers

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -122,6 +122,7 @@ namespace StackExchange.Profiling {
         toggleShortcut: string;
         trivialMilliseconds: number;
         version: string;
+        additionalHeaders: object;
     }
 
     enum RenderMode {
@@ -302,6 +303,7 @@ namespace StackExchange.Profiling {
                 startHidden: bool(data.startHidden),
                 ignoredDuplicateExecuteTypes: (data.ignoredDuplicateExecuteTypes || '').split(','),
                 nonce: script.nonce,
+                additionalHeaders: {},
             };
 
             function doInit() {
@@ -465,8 +467,9 @@ namespace StackExchange.Profiling {
                     method: 'POST',
                     body: JSON.stringify(request),
                     headers: {
+                        ...(this.options.additionalHeaders ?? {}),
                         'Accept': 'application/json',
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
                     }
                 })
                     .then(data => data.text())


### PR DESCRIPTION
Allow the client code to provide additional headers for custom implementations.
Specifically the goal for us is to be able to include authentication using a bearer token, but this solution should cover other custom cases as well.