### PR TITLE
Skip rounding of duration milliseconds.

### DIFF
--- a/src/MiniProfiler.Shared/CustomTiming.cs
+++ b/src/MiniProfiler.Shared/CustomTiming.cs
@@ -37,7 +37,7 @@ namespace StackExchange.Profiling
             CommandString = commandString;
 
             Id = Guid.NewGuid();
-            StartMilliseconds = profiler.GetRoundedMilliseconds(profiler.ElapsedTicks);
+            StartMilliseconds = profiler.GetMilliseconds(profiler.ElapsedTicks);
 
             if (includeStackTrace && !profiler.Options.ExcludeStackTraceSnippetFromCustomTimings)
             {

--- a/src/MiniProfiler.Shared/MiniProfiler.cs
+++ b/src/MiniProfiler.Shared/MiniProfiler.cs
@@ -282,7 +282,7 @@ namespace StackExchange.Profiling
             }
 
             Stopwatch.Stop();
-            DurationMilliseconds = GetRoundedMilliseconds(ElapsedTicks);
+            DurationMilliseconds = GetMilliseconds(ElapsedTicks);
 
             foreach (var timing in GetTimingHierarchy())
             {
@@ -366,13 +366,12 @@ namespace StackExchange.Profiling
             new Timing(this, Head, name, minSaveMs, includeChildrenWithMinSave);
 
         /// <summary>
-        /// Returns milliseconds based on Stopwatch's Frequency, rounded to two decimal places.
+        /// Returns milliseconds based on Stopwatch's Frequency.
         /// </summary>
-        /// <param name="ticks">The tick count to round.</param>
-        internal decimal GetRoundedMilliseconds(long ticks)
+        /// <param name="ticks">The tick count.</param>
+        internal decimal GetMilliseconds(long ticks)
         {
-            long times100 = ticks * 100000 / Stopwatch.Frequency;
-            return times100 / 100m;
+            return ticks * 1000M / Stopwatch.Frequency;
         }
 
         /// <summary>
@@ -380,6 +379,6 @@ namespace StackExchange.Profiling
         /// </summary>
         /// <param name="startTicks">The start tick count.</param>
         internal decimal GetDurationMilliseconds(long startTicks) =>
-            GetRoundedMilliseconds(ElapsedTicks - startTicks);
+            GetMilliseconds(ElapsedTicks - startTicks);
     }
 }

--- a/src/MiniProfiler.Shared/Timing.cs
+++ b/src/MiniProfiler.Shared/Timing.cs
@@ -73,7 +73,7 @@ namespace StackExchange.Profiling
             _startTicks = profiler.ElapsedTicks;
             _minSaveMs = minSaveMs;
             _includeChildrenWithMinSave = includeChildrenWithMinSave == true;
-            StartMilliseconds = profiler.GetRoundedMilliseconds(_startTicks);
+            StartMilliseconds = profiler.GetMilliseconds(_startTicks);
 
             if (profiler.Options.EnableDebugMode)
             {


### PR DESCRIPTION
We built a panel on **miniprofiler** to collect and combine measurements. However, we encountered an issue where tiny call durations were rounded down to zero by **miniprofiler**, particularly problematic when a function is called frequently in the execution path.