### PR TITLE
fix: MiniProfiler.Current.RenderIncludes generates invalid html

### DIFF
--- a/src/MiniProfiler.Shared/Internal/Render.cs
+++ b/src/MiniProfiler.Shared/Internal/Render.cs
@@ -191,7 +191,6 @@ namespace StackExchange.Profiling.Internal
 
             sb.Append("\" data-scheme=\"");
             sb.Append(options.ColorScheme.ToString());
-            sb.Append('"');
 
             sb.Append("\" data-decimal-places=\"");
             sb.Append(options.PopupDecimalPlaces.ToString());


### PR DESCRIPTION
The `RenderIncludes`  method renders invalid html.

The internal `Render` method adds an extra `"` after the `data-scheme`  attribute.

![image](https://github.com/user-attachments/assets/e9276bdb-0614-409d-bbd1-0bb2c32f43cf)

