### PR TITLE
Bug Fix: SQL Profiling Network Time

### DIFF
--- a/src/MiniProfiler.EntityFrameworkCore/RelationalDiagnosticListener.cs
+++ b/src/MiniProfiler.EntityFrameworkCore/RelationalDiagnosticListener.cs
@@ -63,7 +63,7 @@ namespace StackExchange.Profiling.Data
                 if (val is CommandExecutedEventData data && _commands.TryRemove(data.CommandId, out var current))
                 {
                     // A completion for a DataReader only means we *started* getting data back, not finished.
-                    if (data.Result is RelationalDataReader)
+                    if (data.Result is RelationalDataReader or SqlDataReader)
                     {
                         _readers[data.CommandId] = current;
                         current.FirstFetchCompleted();


### PR DESCRIPTION
This fixes: https://github.com/MiniProfiler/dotnet/issues/671

In our configuration `data.Result` is never a `RelationalDataReader`, but is always of type `SqlDataReader` (`System.Data.Common.DbDataReader`). This fixes the conditional so the profiling is logged correctly for both types of data reader.

Before: 

![image](https://github.com/user-attachments/assets/bcb2fd29-3a59-4dfc-a2c9-c81b7e1aac0f)

After:

![image](https://github.com/user-attachments/assets/1edc076d-282b-4ea0-a73c-8e37847536f9)
