### PR TITLE
Fix timings table footer column count when custom timings exist

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -776,6 +776,7 @@ namespace StackExchange.Profiling {
             <tr>
               <td colspan="3"></td>
               <td class="mp-more-columns" colspan="2"></td>
+              ${Object.keys(p.CustomTimingStats).map(() => '<td></td>').join('')}
             </tr>
           </tfoot>
         </table>`;


### PR DESCRIPTION
## Summary

- Fixes a browser warning when MiniProfiler renders profiles with `CustomTimingStats` (for example SQL timings).
- The timings table header adds one column per custom timing type, but the footer row only spanned the fixed five base columns.
- Adds matching empty footer cells so header/body/footer column counts stay aligned.

Fixes #687

## Test plan

- [ ] Build `MiniProfiler.Shared` (TypeScript compile + bundle)
- [ ] Open a profile result that includes custom timings (e.g. SQL)
- [ ] Confirm the browser console no longer reports: "A table row was 5 columns wide, which is less than the column count established by the first row"