### PR TITLE
Resolve ambiguous MiniProfilerExtensions reference

### DIFF
--- a/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
+++ b/src/MiniProfiler.AspNetCore/MiniProfilerExtensions.cs
@@ -7,7 +7,7 @@ namespace StackExchange.Profiling
     /// <summary>
     /// Extension methods for MiniProfiler
     /// </summary>
-    public static class MiniProfilerExtensions
+    public static class MiniProfilerAspNetCoreExtensions
     {
         /// <summary>
         /// Renders script tag for including MiniProfiler.


### PR DESCRIPTION
## Summary

- `MiniProfiler.Shared` and `MiniProfiler.AspNetCore` both declared a `MiniProfilerExtensions` type in `StackExchange.Profiling`.
- Referencing `global::StackExchange.Profiling.MiniProfilerExtensions` (for example from source generators) fails with CS0433 when both assemblies are referenced, such as via `MiniProfiler.AspNetCore.Mvc`.
- Rename the ASP.NET Core extension holder to `MiniProfilerAspNetCoreExtensions`. Extension method usage such as `profiler.RenderIncludes(...)` is unchanged.

Fixes #683

## Test plan

- [ ] Build solution with `MiniProfiler.AspNetCore.Mvc` referenced
- [ ] Confirm `global::StackExchange.Profiling.MiniProfilerExtensions.Step(...)` resolves without CS0433
- [ ] Verify existing `RenderIncludes` extension method calls still compile