### PR TITLE
Fix bottom-positioned popup max-height calculation

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -1054,12 +1054,15 @@ namespace StackExchange.Profiling {
 
                             // is this rendering on the bottom (if no, then is top by default)
                             if (pos === RenderPosition.BottomLeft || pos === RenderPosition.BottomRight) {
-                                const bottom = window.innerHeight - button.getBoundingClientRect().top - button.offsetHeight + window.scrollY; // get bottom of button
                                 popup.style.bottom = '0';
-                                popup.style.maxHeight = 'calc(100vh - ' + (bottom + 25) + 'px)';
+                                popup.style.top = '';
+                                const maxHeight = Math.max(0, button.getBoundingClientRect().top - 25);
+                                popup.style.maxHeight = `${maxHeight}px`;
                             } else {
                                 popup.style.top = '0';
-                                popup.style.maxHeight = 'calc(100vh - ' + (button.getBoundingClientRect().top - window.window.scrollY + 25) + 'px)';
+                                popup.style.bottom = '';
+                                const maxHeight = Math.max(0, window.innerHeight - button.getBoundingClientRect().bottom - 25);
+                                popup.style.maxHeight = `${maxHeight}px`;
                             }
                         }
                         return;


### PR DESCRIPTION
## Summary

- Fixes corner-mode profiler popups that appear too short when `RenderPosition` is `BottomLeft` or `BottomRight`.
- Popups in bottom positions grow upward from the button, but max-height was derived from the distance below the button in the viewport. When the button sits higher on the page, that left only a small max-height.
- Bottom positions now use the space above the button; top positions use the space below the button.

Fixes #696

## Test plan

- [ ] Build `MiniProfiler.Shared`
- [ ] Open a page with MiniProfiler in bottom-left and bottom-right corner mode
- [ ] Click a profiler result and confirm the popup expands to use the available vertical space above the button
- [ ] Verify top-left/top-right positioning still sizes popups correctly