### PR TITLE
Configure Dependabot for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated dependency update PRs.
- Configures weekly checks for NuGet packages across the repository.
- Configures weekly checks for GitHub Actions used in workflows.

Fixes #692

## Test plan

- [ ] Merge and confirm Dependabot opens update PRs for NuGet packages
- [ ] Confirm Dependabot can propose GitHub Actions updates (for example `actions/checkout`)