### PR TITLE
fix: reference Dapper instead of Dapper.StrongName in providers (#693)

### DIFF
--- a/samples/Samples.Console/Samples.Console.csproj
+++ b/samples/Samples.Console/Samples.Console.csproj
@@ -14,7 +14,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
 
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
 
     <ProjectReference Include="..\..\src\MiniProfiler\MiniProfiler.csproj" />

--- a/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
+++ b/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
 
     <ProjectReference Include="..\..\src\MiniProfiler.AspNetCore\MiniProfiler.AspNetCore.csproj" />

--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -8,8 +8,13 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Dapper" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
+++ b/src/MiniProfiler.Providers.MySql/MiniProfiler.Providers.MySql.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.PostgreSql/MiniProfiler.Providers.PostgreSql.csproj
+++ b/src/MiniProfiler.Providers.PostgreSql/MiniProfiler.Providers.PostgreSql.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Npgsql" Version="8.0.6" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.PostgreSql/MiniProfiler.Providers.PostgreSql.csproj
+++ b/src/MiniProfiler.Providers.PostgreSql/MiniProfiler.Providers.PostgreSql.csproj
@@ -8,8 +8,13 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Dapper" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.6" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
+++ b/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
+++ b/src/MiniProfiler.Providers.SqlServer/MiniProfiler.Providers.SqlServer.csproj
@@ -8,8 +8,13 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Dapper" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
+++ b/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />

--- a/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
+++ b/src/MiniProfiler.Providers.Sqlite/MiniProfiler.Providers.Sqlite.csproj
@@ -8,8 +8,13 @@
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Dapper" Version="2.1.35" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
 
     <ProjectReference Include="..\MiniProfiler.Shared\MiniProfiler.Shared.csproj" />


### PR DESCRIPTION
## Summary
- Replace `Dapper.StrongName` with `Dapper` in all SQL provider projects and sample apps
- Avoids `CS0433` when consumers reference the unsigned `Dapper` package (e.g. alongside `Dapper.SqlBuilder`)

Fixes #693

## Test plan
- [ ] CI build passes for provider projects
- [ ] Consumer referencing both `MiniProfiler.Providers.SqlServer` and `Dapper` no longer hits `SqlMapper` type ambiguity