### PR TITLE
docs: note removal of MaxJsonResponseSize setting (#677)

### DIFF
--- a/docs/HowTo/UpgradeFromV3.md
+++ b/docs/HowTo/UpgradeFromV3.md
@@ -36,3 +36,6 @@ MiniProfiler V4 has major breaking changes in layout compared to V3 due to needi
 * `MiniProfilerExtensions.Step(this MiniProfiler profiler, string name, ProfileLevel level)`
 * `MiniProfiler.Stop()` (now an instance method: `MiniProfiler.Current?.Stop()`)
 * UI templating has been removed. While Stylesheets and the `.tmpl` are still replaceable, the `share` and `includes` templates are now much more optimized code. Given the very few people customizing these (was anyone using those pieces?), they certainly weren't worth the performance tradeoffs. If there's a loud demand for them to come back, we'll find a more efficient way to do it.
+
+#### Settings Removed After V4
+* `MiniProfiler.Settings.MaxJsonResponseSize` — removed with the legacy settings API. Profiler JSON is no longer truncated server-side; there is no direct replacement on `MiniProfilerOptions`.

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -6,7 +6,8 @@ layout: "default"
 This page tracks major changes included in any update starting with version 4.0.0.3
 
 #### Unreleased
-No pending unreleased changes.
+- **Removed**:
+  - `MiniProfiler.Settings.MaxJsonResponseSize` was removed with the legacy `MiniProfiler.Settings` API. JSON responses are no longer truncated server-side; use storage/backend limits or client-side handling if large profiler payloads are a concern ([#677](https://github.com/MiniProfiler/dotnet/issues/677)).
 
 #### Version 4.5.4
 - **New**:


### PR DESCRIPTION
## Summary
- Document that `MiniProfiler.Settings.MaxJsonResponseSize` was removed with the legacy settings API
- Clarify there is no direct replacement on `MiniProfilerOptions`

Fixes #677

## Test plan
- [ ] Docs render correctly