### PR TITLE
fix: hook XMLHttpRequest onloadend for axios compatibility (#674)

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -1365,6 +1365,18 @@ namespace StackExchange.Profiling {
                                 }
                             };
                         }
+                    } else if (this.onloadend) {
+                        if (typeof (this.miniprofiler) === 'undefined' || typeof (this.miniprofiler.prev_onloadend) === 'undefined') {
+                            this.miniprofiler = { prev_onloadend: this.onloadend };
+
+                            this.onloadend = function onLoadEndReplacement() {
+                                handleXHR(this);
+
+                                if (this.miniprofiler.prev_onloadend != null) {
+                                    return this.miniprofiler.prev_onloadend.apply(this, arguments);
+                                }
+                            };
+                        }
                     } else if (this.onload) {
                         if (typeof (this.miniprofiler) === 'undefined' || typeof (this.miniprofiler.prev_onload) === 'undefined') {
                             this.miniprofiler = { prev_onload: this.onload };


### PR DESCRIPTION
## Summary

Fixes #674.

Since axios [switched to `onloadend`](https://github.com/axios/axios/pull/3688) instead of `onreadystatechange`, MiniProfiler's XHR `send` wrapper no longer intercepted completed axios requests and profiler results were not fetched automatically.

This adds an `onloadend` hook alongside the existing `onreadystatechange` and `onload` wrappers.

## Changes

- `MiniProfiler.ts`: wrap `XMLHttpRequest.onloadend` when present, mirroring the existing `onload` behavior.

## Test plan

- [ ] CI passes
- [ ] Manual: page using axios shows updated MiniProfiler results after requests complete
- [ ] Existing jQuery/Angular XHR interception behavior unchanged